### PR TITLE
perf(gqa): use SDPA's native GQA broadcast in fp16/bf16

### DIFF
--- a/sapiens/backbones/sapiens2.py
+++ b/sapiens/backbones/sapiens2.py
@@ -364,18 +364,25 @@ class GroupedQueryAttention(nn.Module):
             q = self.q_norm(q)
             k = self.k_norm(k)
 
-        # Repeat KV heads if group ratio >1
-        if self.num_kv_heads != self.num_heads:
+        # GQA: prefer SDPA's native broadcast in fp16/bf16 (FLASH/cuDNN have
+        # GQA-aware kernels). For fp32 those backends reject mismatched head
+        # counts and dispatch falls back to MATH — slower than just
+        # materializing K/V — so keep the explicit repeat there.
+        use_gqa = self.num_kv_heads != self.num_heads
+        if use_gqa and q.dtype not in (torch.bfloat16, torch.float16):
             factor = self.num_heads // self.num_kv_heads
             k = k.repeat_interleave(factor, dim=1)
             v = v.repeat_interleave(factor, dim=1)
+            use_gqa = False
 
         if rope is not None:
             q, k = self.apply_rope(q, k, rope)
 
         # Scaled dot-product attention
         attn_out = self.attn_op(
-            q, k, v, dropout_p=self.attn_drop if self.training else 0.0
+            q, k, v,
+            dropout_p=self.attn_drop if self.training else 0.0,
+            enable_gqa=use_gqa,
         )  # (B, num_heads, N, head_dim)
 
         # Merge heads -> (B, N, embed_dims)

--- a/sapiens/backbones/standalone/sapiens2.py
+++ b/sapiens/backbones/standalone/sapiens2.py
@@ -362,18 +362,25 @@ class GroupedQueryAttention(nn.Module):
             q = self.q_norm(q)
             k = self.k_norm(k)
 
-        # Repeat KV heads if group ratio >1
-        if self.num_kv_heads != self.num_heads:
+        # GQA: prefer SDPA's native broadcast in fp16/bf16 (FLASH/cuDNN have
+        # GQA-aware kernels). For fp32 those backends reject mismatched head
+        # counts and dispatch falls back to MATH — slower than just
+        # materializing K/V — so keep the explicit repeat there.
+        use_gqa = self.num_kv_heads != self.num_heads
+        if use_gqa and q.dtype not in (torch.bfloat16, torch.float16):
             factor = self.num_heads // self.num_kv_heads
             k = k.repeat_interleave(factor, dim=1)
             v = v.repeat_interleave(factor, dim=1)
+            use_gqa = False
 
         if rope is not None:
             q, k = self.apply_rope(q, k, rope)
 
         # Scaled dot-product attention
         attn_out = self.attn_op(
-            q, k, v, dropout_p=self.attn_drop if self.training else 0.0
+            q, k, v,
+            dropout_p=self.attn_drop if self.training else 0.0,
+            enable_gqa=use_gqa,
         )  # (B, num_heads, N, head_dim)
 
         # Merge heads -> (B, N, embed_dims)


### PR DESCRIPTION
## Summary

In `GroupedQueryAttention`, replace the unconditional `repeat_interleave` of K/V heads with `F.scaled_dot_product_attention(..., enable_gqa=True)` on bf16/fp16 inputs. PyTorch's fast SDPA backends (FLASH, cuDNN) have GQA-aware kernels that read the smaller K/V once and broadcast across query-head groups internally — avoiding the materialization of a 2×-larger K/V tensor.

fp32 is intentionally left on the original repeat path: when `enable_gqa=True` is passed in fp32, the FLASH/mem-efficient/cuDNN backends reject mismatched head counts and dispatch falls back to the MATH backend, which is significantly slower than just materializing K/V. The new code branches on dtype to keep the fast path correct in both regimes.

Touches both `sapiens/backbones/sapiens2.py` and the standalone copy at `sapiens/backbones/standalone/sapiens2.py`.

## Verification

All measurements on RTX 5090 (sm_120), torch 2.11.0+cu128, FLASH backend, n=30 reps + 10 warmup, interleaved A/B with CUDA-event timing.

### Correctness — bit-identical end-to-end

Same model instance, same weights, only the attention forward swapped via monkey-patch. Output diffed across the full backbone forward.

| arch | B | resolution | GQA/total layers | bit-equal | max abs diff |
|---|---|---|---|---|---|
| 0.4B | 1 | 1024×768 | 8/24 | ✓ | 0.00e+00 |
| 0.4B | 4 | 1024×768 | 8/24 | ✓ | 0.00e+00 |
| 1B   | 1 | 1024×768 | 24/40 | ✓ | 0.00e+00 |
| 1B   | 4 | 1024×768 | 24/40 | ✓ | 0.00e+00 |
| 1B   | 1 | 1024×1024 | 24/40 | ✓ | 0.00e+00 |
| 5B   | 1 | 1024×768 | 40/56 | ✓ | 0.00e+00 |

### Speed — end-to-end backbone forward (bf16)

| arch | B | resolution | OLD median | NEW median | speedup | Welch t |
|---|---|---|---|---|---|---|
| 0.4B | 1 | 1024×768 | 28.37 ms | 28.46 ms | 0.997× | 0.60 |
| 0.4B | 4 | 1024×768 | 95.46 ms | 94.48 ms | 1.010× | 6.69 |
| 1B   | 1 | 1024×768 | 76.31 ms | 74.94 ms | 1.018× | 8.48 |
| 1B   | 4 | 1024×768 | 283.74 ms | 278.20 ms | **1.020×** | 20.27 |
| 1B   | 1 | 1024×1024 | 106.99 ms | 105.60 ms | 1.013× | 7.47 |
| 5B   | 1 | 1024×768 | 233.44 ms | 230.57 ms | 1.012× | 9.19 |

5/6 cells significant at \|t\|>2. Median speedup ~1.3% e2e; the kernel-isolated SDPA microbench shows ~1.05–1.18× (the rest is amortized over QKV projections, RoPE, FFN, norms). The non-significant 0.4B B=1 cell (smallest config, smallest GQA share) sits in measurement noise.

### Memory — training-mode forward + backward (bf16)

In inference there is no measurable peak-memory change (allocator amortizes the brief K/V expansion). In training the saved-for-backward K/V live for the full forward, so the savings are real:

| arch | B | OLD f+b peak | NEW f+b peak | saved | % |
|---|---|---|---|---|---|
| 0.4B | 1 | 4150 MB | 4102 MB | 48 MB | 1.2% |
| 0.4B | 2 | 8184 MB | 8087 MB | 96 MB | 1.2% |
| 1B   | 1 | 10165 MB | 9949 MB | **217 MB** | 2.1% |
| 1B   | 2 | 20247 MB | 19814 MB | **433 MB** | 2.1% |
| 5B   | 1 | 22823 MB | 22181 MB | **643 MB** | 2.8% |

Savings scale linearly with batch and tokens, and proportionally with the GQA-layer share (8/24 in 0.4B → 40/56 in 5B).

### Why the fp32 branch matters

Without the dtype guard, fp32 callers regress 2–3× because `enable_gqa=True` in fp32 dispatches to MATH (verified by forcing each backend in isolation). The conditional preserves the original fast path for fp32 and only takes the new path where it is faster.

## Test plan

- [x] Output bit-identical to the original implementation across {0.4B, 1B, 5B} × {B=1,4} × {1024×768, 1024×1024}, FLASH + bf16
- [x] Faster e2e in 5/6 cells, all significant (Welch \|t\|>2)
- [x] No peak-memory regression in inference; ~2% reduction in training peak
- [x] fp32 path unchanged (same code as before via dtype guard)
- [x] `flake8 sapiens/` passes on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## References

- [`F.scaled_dot_product_attention` docs](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) — *"Grouped Query Attention (GQA) is an experimental feature. It currently works only for Flash_attention and math kernel on CUDA tensor."* This is what makes the fp32 path a regression: FLASH requires bf16/fp16, and MATH is the unfused reference implementation, so fp32 + `enable_gqa=True` has no fast backend to land on.
- [pytorch/pytorch#154363 — *`scaled_dot_product_attention` broadcasting (GQA) is a memory footgun*](https://github.com/pytorch/pytorch/issues/154363) — same class of issue: GQA configs that look supported can silently fall off the fast path. Open upstream, no fix yet.
- Upstream diagnostic patch: [pytorch/pytorch#181528](https://github.com/pytorch/pytorch/pull/181528) — opened as a draft to add a `TORCH_WARN_ONCE` so the silent MATH fallback documented above becomes self-diagnosing. Independent of this PR; this PR's dtype guard is the user-side workaround that does not require an upstream torch change.
