### PR TITLE
Add human image matting task

### DIFF
--- a/docs/MATTING.md
+++ b/docs/MATTING.md
@@ -1,0 +1,67 @@
+# Sapiens2: Human Image Matting
+
+Per-pixel alpha matting for human subjects. Predicts a soft foreground mask
+(`alpha` in `[0, 1]`) plus a pre-multiplied foreground RGB output.
+
+## Inference Guide
+
+Runs on demo set (`demo/data`, 100 frames) by default:
+
+```bash
+cd $SAPIENS_ROOT/sapiens/dense
+./scripts/demo/matting.sh
+```
+
+Open the script and adjust:
+- `INPUT` — path to your image directory (default: `../../demo/data`)
+- `OUTPUT` — where to save visualizations
+- `MODEL_NAME` — model size (default: `sapiens2_1b`)
+- `JOBS_PER_GPU`, `GPU_IDS` — parallelism (defaults: 3 jobs/GPU on GPUs 0–7)
+
+Outputs per image:
+- Side-by-side visualization: `[input | alpha matte | foreground on chroma green]`
+- `--save_pred` (on by default in the script) additionally writes `<name>_alpha.npy`
+  with the raw alpha as `float32` in `[0, 1]`.
+
+## Training Guide
+
+In-the-wild matting on a mixture of relit / synthetic / captured datasets,
+loaded via the `MattingBaseDataset` (annotation-driven JSON manifest) and
+`MattingGSSDataset` (RGBA image manifest).
+
+The dataset paths and `pretrained_checkpoint` in
+`configs/matting/gss_p3m_metasim/sapiens2_1b_matting_gss_p3m_metasim-1024x768.py`
+point to the internal locations used to train the released model — edit them
+to point at your own data and backbone checkpoint before launching training.
+
+Launch single-node multi-GPU training:
+
+```bash
+cd $SAPIENS_ROOT/sapiens/dense
+./scripts/matting/train/sapiens2_1b/node.sh
+```
+
+Open the script and adjust:
+- `DEVICES` — GPU IDs (default: `0,1,2,3,4,5,6,7`)
+- `TRAIN_BATCH_SIZE_PER_GPU` — per-GPU batch size (default: 8)
+- `mode` — set to `debug` for a single-process run
+
+Outputs are written under `Outputs/matting/train/<MODEL>/node/<timestamp>/`.
+
+## Dataset Format
+
+`MattingBaseDataset` expects an annotation JSON of the form:
+
+```json
+[
+  {"image": "relpath/to/img.png", "mask": "relpath/to/mask.png"},
+  ...
+]
+```
+
+Where `mask` is either:
+- a single-channel alpha image, or
+- an RGBA image whose alpha channel is the matte (RGB channels treated as the
+  pre-multiplied foreground).
+
+`MattingGSSDataset` expects a `.txt` manifest with one RGBA image path per line.

--- a/sapiens/dense/configs/matting/gss_p3m_metasim/sapiens2_1b_matting_gss_p3m_metasim-1024x768.py
+++ b/sapiens/dense/configs/matting/gss_p3m_metasim/sapiens2_1b_matting_gss_p3m_metasim-1024x768.py
@@ -1,0 +1,322 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+_CHECKPOINT_ROOT = os.path.expanduser(
+    os.environ.get("SAPIENS_CHECKPOINT_ROOT", "~/sapiens2_host")
+)
+_DATA_ROOT = os.path.expanduser(os.environ.get("DATA_ROOT", "~/sapiens_data"))
+
+warmup_iters = 500
+
+## 32 nodes, 8 gpus: 256 gpus. bs: 8, global bs: 2048.
+# ~10M samples / 2048 = 4850 iters/epoch
+num_iters = 4850 * 3
+
+# ------------------------------------------------------------------------------
+vis_every_iters = 100
+log_every_iters = 10
+save_every_iters = 1000
+val_every_iters = 1000
+
+# # # # debug
+# vis_every_iters = 1
+# log_every_iters = 1
+# val_every_iters = 2
+# save_every_iters = 1000
+
+load_from = None
+resume = False
+
+# ------------------------------------------------------------------
+model_name = "sapiens2_1b"
+embed_dim = 1536
+num_layers = 40
+num_heads = 24
+
+layer_decay_rate = 0.9
+pretrained_checkpoint = f"{_CHECKPOINT_ROOT}/pretrain/sapiens2_1b_pretrain.safetensors"
+##-----------------------------------------------------------------
+image_size = (1024, 768)  ## height x width
+patch_size = 16
+
+# ------------------------------------------------------------------
+use_fsdp = True
+# use_fsdp = False
+
+use_compile = True
+# use_compile = False
+
+## DDP config
+if use_fsdp is False:
+    accelerator_cfg = dict(
+        type="DDP",
+        log_with="tensorboard",
+        # find_unused_parameters=True,
+        gradient_accumulation_steps=1,  # only accumulation=1 is supported. Otherwise, the LR scheduler will be off.
+        max_interval=num_iters,
+        # mixed_precision="bf16",  # Options: ‘no’,‘fp16’,‘bf16’ or ‘fp8’.
+        step_scheduler_with_optimizer=False,  ## schedule independent of n_gpus
+    )
+
+else:
+    accelerator_cfg = dict(
+        type="FSDP",
+        log_with="tensorboard",
+        gradient_accumulation_steps=1,  # only accumulation=1 is supported. Otherwise, the LR scheduler will be off.
+        max_interval=num_iters,
+        mixed_precision="bf16",  # Options: ‘no’,‘fp16’,‘bf16’ or ‘fp8’.
+        step_scheduler_with_optimizer=False,
+        fsdp_cfg=dict(
+            fsdp_version=2,  # DTensor-based engine
+            state_dict_type="SHARDED_STATE_DICT",  # SHARDED_STATE_DICT | FULL_STATE_DICT
+            # state_dict_type="FULL_STATE_DICT",  # TODO: resume from this is not working
+            mixed_precision=dict(
+                param_dtype="bf16",
+                reduce_dtype="bf16",
+            ),
+            cpu_ram_efficient_loading=False,
+        ),
+    )
+
+if use_compile:
+    accelerator_cfg["compile_cfg"] = dict(
+        backend="inductor",
+        mode="default",  # Options: "default", "reduce-overhead", "max-autotune"
+        fullgraph=False,
+        dynamic=False,
+    )
+
+# ------------------------------------------------------------------
+randomness = dict(seed=0, deterministic=False, diff_rank_seed=True)
+logger = dict(
+    type="Logger",
+    log_interval=log_every_iters,
+)
+checkpoint = dict(
+    type="Checkpointer",
+    save_interval=save_every_iters,
+)
+
+visualizer = dict(
+    type="MattingVisualizer",
+    vis_interval=vis_every_iters,
+    vis_max_samples=4,
+    vis_image_width=384,
+    vis_image_height=512,
+)
+
+
+##-----------------------------------------------------------------
+
+train_pipeline = [
+    dict(
+        type="MattingRandomJPEGCompression",
+        prob=0.5,
+    ),
+    dict(
+        type="MattingCropAlphaBBox",
+        prob=0.5,
+        padding_ratio=(0.0, 0.1),
+    ),
+    dict(
+        type="MattingRandomResize",
+        base_height=image_size[0],
+        base_width=image_size[1],
+        ratio_range=(0.4, 2.0),
+        keep_ratio=True,
+    ),
+    dict(type="MattingRandomCrop", crop_size=image_size),
+    dict(
+        type="MattingRandomRotate",
+        prob=0.5,
+        degree=60,
+        pad_val=(255, 255, 255),
+        seg_pad_val=0,
+    ),  ## the black pixels are set as background
+    dict(
+        type="MattingRandomFlip",
+        prob=0.5,
+    ),
+    dict(
+        type="MattingResize",
+        height=image_size[0],
+        width=image_size[1],
+        keep_ratio=False,
+    ),
+    dict(type="MattingPhotoMetricDistortion"),
+    dict(type="MattingPackInputs"),
+]
+
+gss_train_pipeline = [
+    dict(
+        type="MattingRandomBackground",
+        prob=1.0,
+        background_images_root=[
+            f"{_DATA_ROOT}/matting/backgrounds",
+        ],
+    ),
+    dict(
+        type="MattingRandomJPEGCompression",
+        prob=0.5,
+    ),
+    dict(
+        type="MattingCropAlphaBBox",
+        prob=0.5,
+        padding_ratio=(0.0, 0.1),
+    ),
+    dict(
+        type="MattingRandomResize",
+        base_height=image_size[0],
+        base_width=image_size[1],
+        ratio_range=(0.4, 2.0),
+        keep_ratio=True,
+    ),
+    dict(type="MattingRandomCrop", crop_size=image_size),
+    dict(
+        type="MattingRandomRotate",
+        prob=0.5,
+        degree=60,
+        pad_val=(255, 255, 255),
+        seg_pad_val=0,
+    ),  ## the black pixels are set as background
+    dict(
+        type="MattingRandomFlip",
+        prob=0.5,
+    ),
+    dict(
+        type="MattingResize",
+        height=image_size[0],
+        width=image_size[1],
+        keep_ratio=False,
+    ),
+    dict(type="MattingPhotoMetricDistortion"),
+    dict(type="MattingPackInputs"),
+]
+
+test_pipeline = [
+    dict(
+        type="MattingResize",
+        height=image_size[0],
+        width=image_size[1],
+        keep_ratio=False,
+        test_mode=True,
+    ),
+    dict(type="MattingPackInputs", test_mode=True),
+]
+
+##------------------------------------------------------------------------
+dataset_gss_train = dict(
+    type="MattingGSSDataset",
+    data_root=f"{_DATA_ROOT}/matting/gss",
+    ann_file=f"{_DATA_ROOT}/matting/gss/fgr_pha.txt",
+    pipeline=gss_train_pipeline,
+)
+dataset_p3m_train = dict(
+    type="MattingBaseDataset",
+    data_root=f"{_DATA_ROOT}/matting/p3m",
+    ann_file=f"{_DATA_ROOT}/matting/p3m.json",
+    pipeline=train_pipeline,
+)
+dataset_capturegen4d = dict(
+    type="MattingBaseDataset",
+    data_root=f"{_DATA_ROOT}/matting/capturegen4d",
+    ann_file=f"{_DATA_ROOT}/matting/capturegen4d.json",
+    pipeline=train_pipeline,
+)
+dataset_metasim = dict(
+    type="MattingBaseDataset",
+    data_root=f"{_DATA_ROOT}/matting/metasim",
+    ann_file=f"{_DATA_ROOT}/matting/metasim.json",
+    pipeline=train_pipeline,
+)
+
+train_datasets = [
+    dataset_gss_train,
+    dataset_p3m_train,
+    dataset_capturegen4d,
+    dataset_metasim,
+]
+train_dataloader = dict(
+    batch_size=1,
+    num_workers=4,
+    persistent_workers=True,
+    shuffle=True,
+    dataset=dict(
+        type="CombinedDataset",
+        datasets=train_datasets,
+    ),
+)
+
+val_dataloader = None
+
+val_cfg = None
+
+data_preprocessor = dict(
+    type="ImagePreprocessor",
+    mean=[123.675, 116.28, 103.53],
+    std=[58.395, 57.12, 57.375],
+    bgr_to_rgb=True,  ## convert from bgr to rgb for pretrained models
+)
+
+##-----------------------------------------------------------------
+model = dict(
+    type="MattingEstimator",
+    backbone=dict(
+        type="Sapiens2",
+        arch=model_name,
+        img_size=image_size,
+        patch_size=patch_size,
+        final_norm=True,
+        use_tokenizer=False,
+        with_cls_token=True,
+        out_type="featmap",
+        init_cfg=dict(type="Pretrained", checkpoint=pretrained_checkpoint),
+    ),
+    decode_head=dict(
+        type="MattingHead",
+        in_channels=embed_dim,
+        upsample_channels=[768, 512, 256, 128],  ## 1K resolution
+        conv_out_channels=[64, 32, 16],
+        conv_kernel_sizes=[3, 3, 3],
+        out_channels=4,
+        loss_decode=[
+            dict(type="MattingL1Loss", loss_weight=1.0),
+            dict(type="MattingGradLoss", loss_weight=1.0),
+            dict(type="MattingLaplacianLoss", loss_weight=1.0),
+        ],
+    ),
+)
+
+
+##-----------------------------------------------------------------
+optimizer = dict(
+    type="AdamW",
+    lr=5e-4,
+    betas=(0.9, 0.999),
+    weight_decay=0.1,
+    paramwise_cfg=dict(
+        num_layers=num_layers,
+        layer_decay_rate=layer_decay_rate,
+    ),
+    fused=True,
+)
+
+scheduler = dict(
+    type="SequentialLR",
+    milestones=[warmup_iters],
+    schedulers=[
+        dict(type="LinearLR", start_factor=1e-3, total_iters=warmup_iters),
+        dict(
+            type="PolynomialLR",
+            total_iters=num_iters - warmup_iters,
+            power=1.0,
+        ),
+    ],
+)
+
+clip_grad = dict(mode="norm", max_norm=4.0, norm_type=2.0)

--- a/sapiens/dense/scripts/demo/matting.sh
+++ b/sapiens/dense/scripts/demo/matting.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Run human matting on a directory of images.
+
+cd "$(dirname "$(realpath "$0")")/../.." || exit
+SAPIENS_CHECKPOINT_ROOT="${SAPIENS_CHECKPOINT_ROOT:-${HOME}/sapiens2_host}"
+
+#----------------------------set your input and output directories-------------------------
+INPUT='../../demo/data'
+OUTPUT="${HOME}/Desktop/sapiens2/matting/Outputs/vis"
+
+#--------------------------MODEL CARD (uncomment one)---------------------------------------
+MODEL_NAME='sapiens2_1b';   CHECKPOINT="${SAPIENS_CHECKPOINT_ROOT}/matting/sapiens2_1b_matting.safetensors"
+
+DATASET='gss_p3m_metasim'
+MODEL="${MODEL_NAME}_matting_${DATASET}-1024x768"
+CONFIG_FILE="configs/matting/${DATASET}/${MODEL}.py"
+OUTPUT="${OUTPUT}/${MODEL_NAME}"
+
+##-------------------------------------inference--------------------------------------------
+RUN_FILE='tools/vis/vis_matting.py'
+
+JOBS_PER_GPU=3; GPU_IDS=(0 1 2 3 4 5 6 7)
+# JOBS_PER_GPU=1; GPU_IDS=(0)
+TOTAL_JOBS=$((JOBS_PER_GPU * ${#GPU_IDS[@]}))
+
+IMAGE_LIST="${INPUT}/image_list.txt"
+find "${INPUT}" -type f \( -iname \*.jpg -o -iname \*.jpeg -o -iname \*.png \) | sort > "${IMAGE_LIST}"
+
+if [ ! -s "${IMAGE_LIST}" ]; then
+  echo "No images found at ${INPUT}"
+  exit 1
+fi
+
+NUM_IMAGES=$(wc -l < "${IMAGE_LIST}")
+IMAGES_PER_FILE=$((NUM_IMAGES / TOTAL_JOBS))
+EXTRA_IMAGES=$((NUM_IMAGES % TOTAL_JOBS))
+
+export TF_CPP_MIN_LOG_LEVEL=2
+echo "Distributing ${NUM_IMAGES} image paths into ${TOTAL_JOBS} jobs."
+
+current_line=1
+for ((i=0; i<TOTAL_JOBS; i++)); do
+  TEXT_FILE="${INPUT}/image_paths_$((i+1)).txt"
+  if [ $i -lt $EXTRA_IMAGES ]; then
+    images_for_this_job=$((IMAGES_PER_FILE + 1))
+  else
+    images_for_this_job=$IMAGES_PER_FILE
+  fi
+  if [ $images_for_this_job -gt 0 ]; then
+    sed -n "${current_line},$((current_line + images_for_this_job - 1))p" "${IMAGE_LIST}" > "${TEXT_FILE}"
+    current_line=$((current_line + images_for_this_job))
+  else
+    touch "${TEXT_FILE}"
+  fi
+done
+
+for ((i=0; i<TOTAL_JOBS; i++)); do
+  GPU_ID=${GPU_IDS[$((i % ${#GPU_IDS[@]}))]}
+  CMD="CUDA_VISIBLE_DEVICES=${GPU_ID} python ${RUN_FILE} \
+    ${CONFIG_FILE} \
+    ${CHECKPOINT} \
+    --save_pred \
+    --input \"${INPUT}/image_paths_$((i+1)).txt\" \
+    --output \"${OUTPUT}\""
+  [ "$TOTAL_JOBS" -gt 1 ] && CMD="$CMD &"
+  eval $CMD
+  sleep 1
+done
+
+wait
+
+rm "${IMAGE_LIST}"
+for ((i=0; i<TOTAL_JOBS; i++)); do
+  rm "${INPUT}/image_paths_$((i+1)).txt"
+done
+
+echo "Output directory: ${OUTPUT}"

--- a/sapiens/dense/scripts/matting/train/sapiens2_1b/node.sh
+++ b/sapiens/dense/scripts/matting/train/sapiens2_1b/node.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+cd "$(dirname "$(realpath "$0")")/../../../.." || exit
+
+#-------------------------------------------------------------------------------
+DEVICES=0,1,2,3,4,5,6,7
+# DEVICES=0
+
+#-------------------------------------------------------------------------------
+TASK="matting"
+DATASET="gss_p3m_metasim"
+MODEL="sapiens2_1b_${TASK}_${DATASET}-1024x768"
+
+CONFIG_FILE="configs/${TASK}/$DATASET/${MODEL}.py"
+TRAIN_BATCH_SIZE_PER_GPU=8
+
+
+#-------------------------------------------------------------------------------
+# mode='debug'
+mode='multi-gpu'
+
+#-------------------------------------------------------------------------------
+OUTPUT_DIR="Outputs/${TASK}/train/${MODEL}/node"
+OUTPUT_DIR="$(echo "${OUTPUT_DIR}/$(date +"%m-%d-%Y_%H:%M:%S")")"
+
+#-------------------------------------------------------------------------------
+OPTIONS="train_dataloader.batch_size=$TRAIN_BATCH_SIZE_PER_GPU"
+OPTIONS="${OPTIONS}${LOAD_FROM:+ load_from=$LOAD_FROM}"
+CMD_RESUME="${RESUME_FROM:+--resume $RESUME_FROM}"
+
+export TF_CPP_MIN_LOG_LEVEL=2
+PORT=$(( ((RANDOM<<15)|RANDOM) % 63001 + 2000 ))
+
+#-------------------------------------------------------------------------------
+if [ "$mode" = "debug" ]; then
+    export TORCH_DISTRIBUTED_DEBUG=DETAIL
+    TRAIN_BATCH_SIZE_PER_GPU=1
+    OPTIONS="train_dataloader.batch_size=${TRAIN_BATCH_SIZE_PER_GPU} train_dataloader.num_workers=0 train_dataloader.persistent_workers=False"
+    OPTIONS="${OPTIONS}${LOAD_FROM:+ load_from=$LOAD_FROM}"
+
+    CUDA_VISIBLE_DEVICES=${DEVICES} python tools/train.py ${CONFIG_FILE} \
+        --work-dir ${OUTPUT_DIR} \
+        --cfg-options ${OPTIONS} \
+        ${CMD_RESUME}
+
+elif [ "$mode" = "multi-gpu" ]; then
+    NUM_GPUS=$(echo $DEVICES | tr -s ',' ' ' | wc -w)
+
+    LOG_FILE="${OUTPUT_DIR}/log.txt"
+    mkdir -p ${OUTPUT_DIR}
+    touch ${LOG_FILE}
+
+    CUDA_VISIBLE_DEVICES=${DEVICES} PORT=${PORT} 'tools/dist_train.sh' ${CONFIG_FILE} \
+        ${NUM_GPUS} \
+        --work-dir ${OUTPUT_DIR} \
+        --cfg-options ${OPTIONS} \
+        ${CMD_RESUME} \
+        | tee ${LOG_FILE}
+fi

--- a/sapiens/dense/src/datasets/matting/__init__.py
+++ b/sapiens/dense/src/datasets/matting/__init__.py
@@ -4,9 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .seg import *
-from .normal import *
-from .albedo import *
-from .pointmap import *
-from .transforms import *
-from .matting import *
+from .matting_base_dataset import MattingBaseDataset
+from .matting_gss_dataset import MattingGSSDataset
+
+__all__ = ["MattingBaseDataset", "MattingGSSDataset"]

--- a/sapiens/dense/src/datasets/matting/matting_base_dataset.py
+++ b/sapiens/dense/src/datasets/matting/matting_base_dataset.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import os
+from typing import List
+
+import numpy as np
+from sapiens.engine.datasets import BaseDataset
+from sapiens.registry import DATASETS
+from typedio.auto import typed
+
+
+##-----------------------------------------------------------------------
+@DATASETS.register_module()
+class MattingBaseDataset(BaseDataset):
+    def __init__(self, ann_file, **kwargs) -> None:
+        self.ann_file = ann_file
+        super().__init__(**kwargs)
+        return
+
+    def load_data_list(self) -> List[dict]:
+        """Load annotation from directory or annotation file.
+        modify this function to load a list of all sample information in training
+
+        Returns:
+            list[dict]: All data info of dataset.
+        """
+        raw_data = typed.load(self.ann_file)
+
+        data_list = [
+            {
+                "image_path": os.path.join(self.data_root, sample["image"]),
+                "mask_path": os.path.join(self.data_root, sample["mask"]),
+            }
+            for sample in raw_data
+        ]
+
+        print(
+            "\033[92mDone! {}. Loaded total samples: {}. Test mode: {}\033[0m".format(
+                self.__class__.__name__, len(data_list), self.test_mode
+            )
+        )
+
+        return data_list
+
+    def get_data_info(self, idx):
+        data_info = copy.deepcopy(self.data_list[idx])
+
+        try:
+            img = typed.load(data_info["image_path"])  # rgb
+            img = img[..., [2, 1, 0]]  # rgb -> bgr
+
+            mask = typed.load(data_info["mask_path"]).astype(np.float32)
+        except Exception as e:
+            print(f"Error loading image/mask {data_info}: {e}")
+            return None
+
+        fgr = None
+        if mask.ndim == 3 and mask.shape[-1] == 4:
+            fgr = mask[..., [2, 1, 0]]  # rgb -> bgr
+            alpha = mask[..., -1] / 255.0
+
+            fgr = (fgr * alpha[..., None]).astype(np.uint8)  # pre-multiply alpha
+        elif mask.ndim == 3 and (mask.shape[-1] == 3 or mask.shape[-1] == 1):
+            # mask could be HxWx3 with same values in each channel
+            alpha = mask[..., 0] / 255.0
+        elif mask.ndim == 2:
+            alpha = mask / 255.0
+        else:
+            print(f"Unexpected mask shape {mask.shape} for {data_info}")
+            return None
+
+        data_info = {
+            "img": img,
+            "img_id": "",
+            "img_path": data_info["image_path"],
+            "alpha": alpha,
+            "id": idx,
+        }
+
+        if fgr is not None:
+            data_info["fgr"] = fgr
+
+        return data_info

--- a/sapiens/dense/src/datasets/matting/matting_gss_dataset.py
+++ b/sapiens/dense/src/datasets/matting/matting_gss_dataset.py
@@ -1,0 +1,72 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import os
+from typing import List
+
+import numpy as np
+from sapiens.registry import DATASETS
+from typedio.auto import typed
+
+from .matting_base_dataset import MattingBaseDataset
+
+
+##-----------------------------------------------------------------------
+@DATASETS.register_module()
+class MattingGSSDataset(MattingBaseDataset):
+    def load_data_list(self) -> List[dict]:
+        """Load annotation from directory or annotation file.
+        modify this function to load a list of all sample information in training
+
+        Returns:
+            list[dict]: All data info of dataset.
+        """
+        raw_data = typed.load(self.ann_file)
+        image_paths = raw_data.split("\n")
+
+        data_list = []
+        for file_path in image_paths:
+            if not file_path:
+                continue
+
+            data_list.append(
+                {
+                    "image_path": os.path.join(self.data_root, file_path.strip()),
+                }
+            )
+
+        print(
+            "\033[92mDone! {}. Loaded total samples: {}. Test mode: {}\033[0m".format(
+                self.__class__.__name__, len(data_list), self.test_mode
+            )
+        )
+
+        return data_list
+
+    def get_data_info(self, idx):
+        data_info = copy.deepcopy(self.data_list[idx])
+
+        img = typed.load(data_info["image_path"])  # RGBA
+        #  GSS images are 16-bit pngs, so we need to convert them to 8-bit
+        if img.dtype == np.uint16:
+            img = (img / 256).astype(np.uint8)
+
+        bgr = img[..., [2, 1, 0]]  # RGB to BGR
+
+        mask = img[:, :, 3].astype(np.float32) / 255.0
+        fgr = (bgr.astype(np.float32) * mask[..., None]).astype(np.uint8)
+
+        data_info = {
+            "img": bgr,
+            "img_id": "",
+            "img_path": data_info["image_path"],
+            "alpha": mask,
+            "fgr": fgr,
+            "id": idx,
+        }
+
+        return data_info

--- a/sapiens/dense/src/datasets/transforms/__init__.py
+++ b/sapiens/dense/src/datasets/transforms/__init__.py
@@ -13,6 +13,18 @@ from .albedo_transforms import (
     AlbedoResize,
     AlbedoResizePadImage,
 )
+from .matting_transforms import (
+    MattingCropAlphaBBox,
+    MattingPackInputs,
+    MattingPhotoMetricDistortion,
+    MattingRandomBackground,
+    MattingRandomCrop,
+    MattingRandomFlip,
+    MattingRandomJPEGCompression,
+    MattingRandomResize,
+    MattingRandomRotate,
+    MattingResize,
+)
 from .normal_transforms import (
     NormalGenerateTarget,
     NormalPackInputs,
@@ -74,4 +86,14 @@ __all__ = [
     "AlbedoRandomScale",
     "AlbedoResize",
     "AlbedoResizePadImage",
+    "MattingRandomFlip",
+    "MattingRandomCrop",
+    "MattingResize",
+    "MattingRandomResize",
+    "MattingRandomRotate",
+    "MattingPhotoMetricDistortion",
+    "MattingPackInputs",
+    "MattingRandomBackground",
+    "MattingCropAlphaBBox",
+    "MattingRandomJPEGCompression",
 ]

--- a/sapiens/dense/src/datasets/transforms/matting_transforms.py
+++ b/sapiens/dense/src/datasets/transforms/matting_transforms.py
@@ -1,0 +1,866 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import random
+from typing import Dict, Final, List, Optional, Sequence, Tuple, Union
+
+import cv2
+import numpy as np
+import torch
+from sapiens.engine.datasets import BaseTransform, to_tensor
+from sapiens.registry import TRANSFORMS
+
+
+MAT_REC2020_TO_XYZ: Final[np.ndarray] = np.array(
+    [
+        [6.3695806e-01, 2.6270020e-01, 3.5174702e-10],
+        [1.4461690e-01, 6.7799807e-01, 2.8072692e-02],
+        [1.6888097e-01, 5.9301715e-02, 1.0609850e00],
+    ],
+    dtype=np.float32,
+)
+
+MAT_XYZ_TO_REC709: Final[np.ndarray] = np.array(
+    [
+        [3.2404542, -0.969266, 0.0556434],
+        [-1.5371385, 1.8760108, -0.2040259],
+        [-0.4985314, 0.041556, 1.0572252],
+    ],
+    dtype=np.float32,
+)
+
+
+@TRANSFORMS.register_module()
+class MattingRandomFlip(BaseTransform):
+    def __init__(self, prob=0.5) -> None:
+        super().__init__()
+        self.prob = prob
+
+    def _flip(self, results: dict) -> None:
+        """Flip images, masks, depth maps and adjust camera parameters."""
+        # Flip image
+        results["img"] = cv2.flip(results["img"], 1)  # 1 for horizontal flip
+        results["alpha"] = cv2.flip(results["alpha"], 1)
+
+        if "fgr" in results:
+            results["fgr"] = cv2.flip(results["fgr"], 1)  # 1 for horizontal flip
+
+    def transform(self, results: Dict) -> Optional[Union[Dict, Tuple[List, List]]]:
+        if np.random.rand() < self.prob:
+            self._flip(results)
+        return results
+
+
+@TRANSFORMS.register_module()
+class MattingRandomCrop(BaseTransform):
+    def __init__(self, crop_size: Tuple[int, int], prob: float = 0.5):
+        super().__init__()
+
+        assert len(crop_size) == 2 and crop_size[0] > 0 and crop_size[1] > 0, (
+            f"Invalid crop size: {crop_size}"
+        )
+
+        self.crop_size = crop_size
+        self.prob = prob
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(crop_size={self.crop_size}, prob={self.prob})"
+        )
+
+    def _get_crop_bbox(self, img: np.ndarray, crop_h: int, crop_w: int) -> tuple:
+        """Randomly generate a crop bounding box for an image given target (h, w)."""
+        h, w = img.shape[:2]
+
+        # Ensure the target crop is not bigger than the image
+        crop_h = min(crop_h, h)
+        crop_w = min(crop_w, w)
+
+        margin_h = h - crop_h
+        margin_w = w - crop_w
+
+        # Random top-left corner
+        offset_h = np.random.randint(0, margin_h + 1)
+        offset_w = np.random.randint(0, margin_w + 1)
+
+        y1, y2 = offset_h, offset_h + crop_h
+        x1, x2 = offset_w, offset_w + crop_w
+        return (y1, y2, x1, x2)
+
+    def _crop_img(self, img: np.ndarray, crop_bbox: tuple) -> np.ndarray:
+        """Crop image to bbox = (y1, y2, x1, x2)."""
+        y1, y2, x1, x2 = crop_bbox
+        return img[y1:y2, x1:x2, ...]
+
+    def transform(self, results: dict) -> dict:
+        # Decide whether to apply cropping
+        if np.random.rand() >= self.prob:
+            return results  # skip cropping
+
+        img = results["img"]
+        # Pick one (h, w) from the list of possible crop sizes
+
+        crop_h, crop_w = self.crop_size
+
+        # Generate the crop bounding box
+        crop_bbox = self._get_crop_bbox(img, crop_h, crop_w)
+
+        # Apply to the main image
+        cropped_img = self._crop_img(img, crop_bbox)
+
+        results["img"] = cropped_img
+        results["img_shape"] = cropped_img.shape[:2]
+
+        # Crop other maps if they exist
+        for key in ["alpha", "fgr"]:
+            if key in results:
+                results[key] = self._crop_img(results[key], crop_bbox)
+
+        return results
+
+
+@TRANSFORMS.register_module()
+class MattingResize(BaseTransform):
+    def __init__(
+        self,
+        height=1024,
+        width=768,
+        keep_ratio=False,
+        test_mode: bool = False,
+    ):
+        super().__init__()
+        self.height = height
+        self.width = width
+        self.keep_ratio = keep_ratio
+        self.test_mode = test_mode
+
+    def transform(self, results: Dict) -> Dict:
+        img = results["img"]
+        h, w = img.shape[:2]
+
+        target_height = self.height
+        target_width = self.width
+
+        if self.keep_ratio is True:
+            scale_factor = min(target_width / w, target_height / h)
+            new_w = int(round(w * scale_factor))
+            new_h = int(round(h * scale_factor))
+
+        else:
+            new_w = target_width
+            new_h = target_height
+
+        dsize = (new_w, new_h)
+
+        # Use INTER_AREA for shrinking and INTER_CUBIC for enlarging
+        # to get antialiased results.
+        img_interpolation = cv2.INTER_AREA if new_w < w else cv2.INTER_LINEAR
+
+        # Update the results dictionary
+        results["img"] = cv2.resize(img, dsize, interpolation=img_interpolation)
+        results["img_shape"] = results["img"].shape[:2]
+
+        # Resize gt alpha/foreground if training
+        if "alpha" in results and self.test_mode is False:
+            results["alpha"] = cv2.resize(
+                results["alpha"], dsize, interpolation=cv2.INTER_LINEAR
+            )
+        if "fgr" in results and self.test_mode is False:
+            results["fgr"] = cv2.resize(
+                results["fgr"], dsize, interpolation=cv2.INTER_LINEAR
+            )
+        return results
+
+
+@TRANSFORMS.register_module()
+class MattingRandomResize(BaseTransform):
+    def __init__(
+        self,
+        base_height=1024,
+        base_width=768,
+        ratio_range=(0.4, 2.0),
+        keep_ratio=True,
+    ):
+        super().__init__()
+        self.base_height = base_height
+        self.base_width = base_width
+        self.ratio_range = ratio_range
+        self.keep_ratio = keep_ratio
+        self.resizer = MattingResize(
+            height=self.base_height, width=self.base_width, keep_ratio=keep_ratio
+        )
+
+    def transform(self, results: dict) -> dict:
+        min_ratio, max_ratio = self.ratio_range
+        ratio = np.random.random_sample() * (max_ratio - min_ratio) + min_ratio
+        self.resizer.height = int(self.base_height * ratio)
+        self.resizer.width = int(self.base_width * ratio)
+        return self.resizer.transform(results)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"base_height={self.base_height}, "
+            f"base_width={self.base_width}, "
+            f"ratio_range={self.ratio_range}, "
+            f"keep_ratio={self.keep_ratio})"
+        )
+
+
+@TRANSFORMS.register_module()
+class MattingRandomRotate(BaseTransform):
+    def __init__(
+        self,
+        prob=0.5,
+        degree=60,
+        pad_val=0,
+        seg_pad_val=0,
+    ):
+        super().__init__()
+        self.prob = prob
+        assert prob >= 0 and prob <= 1
+        assert degree > 0, f"degree {degree} should be positive"
+        self.degree = (-degree, degree)
+        assert len(self.degree) == 2, (
+            f"degree {self.degree} should be a tuple of (min, max)"
+        )
+        self.pad_val = pad_val
+        self.seg_pad_val = seg_pad_val
+
+    def transform(self, results: dict) -> dict:
+        if random.random() > self.prob:
+            return results
+
+        degree = random.uniform(min(*self.degree), max(*self.degree))
+        img = results["img"]
+        alpha = results["alpha"]
+        h, w = img.shape[:2]
+        center = (w / 2, h / 2)
+
+        M = cv2.getRotationMatrix2D(center, degree, 1.0)
+
+        results["img"] = cv2.warpAffine(
+            img, M, (w, h), flags=cv2.INTER_LINEAR, borderValue=self.pad_val
+        )
+
+        # Rotate the alpha map and foreground
+        results["alpha"] = cv2.warpAffine(
+            alpha,
+            M,
+            (w, h),
+            flags=cv2.INTER_LINEAR,
+            borderValue=self.seg_pad_val,
+        )
+        if "fgr" in results:
+            results["fgr"] = cv2.warpAffine(
+                results["fgr"],
+                M,
+                (w, h),
+                flags=cv2.INTER_LINEAR,
+                borderValue=0,
+            )
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += (
+            f"(prob={self.prob}, "
+            f"degree={self.degree}, "
+            f"pad_val={self.pad_val}, "
+            f"seg_pad_val={self.seg_pad_val}, "
+        )
+        return repr_str
+
+
+@TRANSFORMS.register_module()
+class MattingPhotoMetricDistortion(BaseTransform):
+    def __init__(
+        self,
+        brightness_delta: int = 32,
+        contrast_range: Sequence[float] = (0.5, 1.5),
+        saturation_range: Sequence[float] = (0.5, 1.5),
+        hue_delta: int = 18,
+        prob: float = 0.5,
+    ):
+        self.brightness_delta = brightness_delta
+        self.contrast_lower, self.contrast_upper = contrast_range
+        self.saturation_lower, self.saturation_upper = saturation_range
+        self.hue_delta = hue_delta
+        self.prob = prob
+
+    def convert(
+        self,
+        img: np.ndarray | None,
+        alpha: int = 1,
+        beta: int = 0,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        """Multiple with alpha and add beta with clip.
+
+        Args:
+            img (np.ndarray): The input image.
+            alpha (int): Image weights, change the contrast/saturation
+                of the image. Default: 1
+            beta (int): Image bias, change the brightness of the
+                image. Default: 0
+            fgr (Optional[np.ndarray]): Optional foreground image to apply
+                the same transformation. Default: None
+
+        Returns:
+            np.ndarray or Tuple[np.ndarray, np.ndarray]: The transformed image,
+                or tuple of (transformed img, transformed fgr) if fgr is provided.
+        """
+        if img is None:
+            return None
+
+        img = img.astype(np.float32) * alpha + beta
+        img = np.clip(img, 0, 255)
+        img = img.astype(np.uint8)
+
+        return img
+
+    def brightness(
+        self, img: np.ndarray, fgr: Optional[np.ndarray] = None
+    ) -> Tuple[np.ndarray, np.ndarray | None]:
+        """Brightness distortion.
+
+        Args:
+            img (np.ndarray): The input image.
+            fgr (Optional[np.ndarray]): Optional foreground image to apply
+                the same transformation. Default: None
+        Returns:
+            np.ndarray or Tuple[np.ndarray, np.ndarray]: Image after brightness change,
+                or tuple of (transformed img, transformed fgr) if fgr is provided.
+        """
+
+        if random.randint(0, 1):
+            beta = random.uniform(-self.brightness_delta, self.brightness_delta)
+            img = self.convert(img, beta=beta)
+            fgr = self.convert(fgr, beta=beta)
+
+        return img, fgr
+
+    def contrast(
+        self, img: np.ndarray, fgr: Optional[np.ndarray] = None
+    ) -> Tuple[np.ndarray, np.ndarray | None]:
+        """Contrast distortion.
+
+        Args:
+            img (np.ndarray): The input image.
+            fgr (Optional[np.ndarray]): Optional foreground image to apply
+                the same transformation. Default: None
+        Returns:
+            np.ndarray or Tuple[np.ndarray, np.ndarray]: Image after contrast change,
+                or tuple of (transformed img, transformed fgr) if fgr is provided.
+        """
+
+        if random.randint(0, 1):
+            alpha = random.uniform(self.contrast_lower, self.contrast_upper)
+            img = self.convert(img, alpha=alpha)
+            fgr = self.convert(fgr, alpha=alpha)
+        return img, fgr
+
+    def saturation(
+        self, img: np.ndarray, fgr: Optional[np.ndarray] = None
+    ) -> Tuple[np.ndarray, np.ndarray | None]:
+        """Saturation distortion.
+
+        Args:
+            img (np.ndarray): The input image.
+            fgr (Optional[np.ndarray]): Optional foreground image to apply
+                the same transformation. Default: None
+        Returns:
+            np.ndarray or Tuple[np.ndarray, np.ndarray]: Image after saturation change,
+                or tuple of (transformed img, transformed fgr) if fgr is provided.
+        """
+
+        if random.randint(0, 1):
+            alpha = random.uniform(self.saturation_lower, self.saturation_upper)
+            img_hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+            img_hsv[:, :, 1] = self.convert(img_hsv[:, :, 1], alpha=alpha)
+            img = cv2.cvtColor(img_hsv, cv2.COLOR_HSV2BGR)
+
+            if fgr is not None:
+                fgr_hsv = cv2.cvtColor(fgr, cv2.COLOR_BGR2HSV)
+                fgr_hsv[:, :, 1] = self.convert(fgr_hsv[:, :, 1], alpha=alpha)
+                fgr = cv2.cvtColor(fgr_hsv, cv2.COLOR_HSV2BGR)
+
+        return img, fgr
+
+    def hue(
+        self, img: np.ndarray, fgr: Optional[np.ndarray] = None
+    ) -> Tuple[np.ndarray, np.ndarray | None]:
+        """Hue distortion.
+
+        Args:
+            img (np.ndarray): The input image.
+            fgr (Optional[np.ndarray]): Optional foreground image to apply
+                the same transformation. Default: None
+        Returns:
+            np.ndarray or Tuple[np.ndarray, np.ndarray]: Image after hue change,
+                or tuple of (transformed img, transformed fgr) if fgr is provided.
+        """
+
+        if random.randint(0, 1):
+            delta = random.randint(-self.hue_delta, self.hue_delta)
+            img_hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+            img_hsv[:, :, 0] = (img_hsv[:, :, 0].astype(int) + delta) % 180
+            img = cv2.cvtColor(img_hsv, cv2.COLOR_HSV2BGR)
+            if fgr is not None:
+                fgr_hsv = cv2.cvtColor(fgr, cv2.COLOR_BGR2HSV)
+                fgr_hsv[:, :, 0] = (fgr_hsv[:, :, 0].astype(int) + delta) % 180
+                fgr = cv2.cvtColor(fgr_hsv, cv2.COLOR_HSV2BGR)
+
+        return img, fgr
+
+    def transform(self, results: dict) -> dict:
+        """Transform function to perform photometric distortion on images.
+
+        Args:
+            results (dict): Result dict from loading pipeline.
+
+        Returns:
+            dict: Result dict with images distorted.
+        """
+        if np.random.rand() > self.prob:
+            return results
+
+        img = results["img"]
+        fgr = results.get("fgr", None)
+
+        # random brightness
+        img, fgr = self.brightness(img, fgr)
+
+        # mode == 0 --> do random contrast first
+        # mode == 1 --> do random contrast last
+        mode = random.randint(0, 1)
+        if mode == 1:
+            img, fgr = self.contrast(img, fgr)
+
+        # random saturation
+        img, fgr = self.saturation(img, fgr)
+
+        # random hue
+        img, fgr = self.hue(img, fgr)
+
+        # random contrast
+        if mode == 0:
+            img, fgr = self.contrast(img, fgr)
+
+        results["img"] = img
+
+        if fgr is not None:
+            fgr[results["alpha"] == 0] = 0
+            results["fgr"] = fgr
+
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += (
+            f"(brightness_delta={self.brightness_delta}, "
+            f"contrast_range=({self.contrast_lower}, "
+            f"{self.contrast_upper}), "
+            f"saturation_range=({self.saturation_lower}, "
+            f"{self.saturation_upper}), "
+            f"hue_delta={self.hue_delta})"
+        )
+        return repr_str
+
+
+@TRANSFORMS.register_module()
+class MattingPackInputs(BaseTransform):
+    def __init__(
+        self,
+        test_mode: bool = False,
+        meta_keys=(
+            "img_path",
+            "ori_shape",
+            "img_shape",
+            "pad_shape",
+            "flip",
+        ),
+    ):
+        super().__init__()
+        self.test_mode = test_mode
+        self.meta_keys = meta_keys
+
+    def transform(self, results: dict) -> dict:
+        packed_results = dict()
+        if "img" in results:
+            img = results["img"]
+            if len(img.shape) < 3:
+                img = np.expand_dims(img, -1)
+            if not img.flags.c_contiguous:
+                img = to_tensor(np.ascontiguousarray(img.transpose(2, 0, 1)))
+            else:
+                img = img.transpose(2, 0, 1)
+                img = to_tensor(img).contiguous()
+            packed_results["inputs"] = img
+
+        data_sample = dict()
+
+        if "alpha" in results:
+            data_sample["gt_alpha"] = to_tensor(results["alpha"].squeeze()[None, ...])
+        if "fgr" in results:
+            gt_fgr = results["fgr"].astype(np.float32) / 255.0
+            gt_fgr = np.ascontiguousarray(gt_fgr.transpose(2, 0, 1)[[2, 1, 0], ...])
+            data_sample["gt_foreground"] = to_tensor(gt_fgr)
+            data_sample["has_foreground"] = True
+            data_sample["mask"] = torch.full(
+                (1, data_sample["gt_alpha"].shape[1], data_sample["gt_alpha"].shape[2]),
+                True,
+                dtype=torch.bool,
+            )
+        else:
+            if not self.test_mode:
+                gt_fgr = torch.zeros(
+                    3,
+                    data_sample["gt_alpha"].shape[1],
+                    data_sample["gt_alpha"].shape[2],
+                    dtype=data_sample["gt_alpha"].dtype,
+                )
+                mask = data_sample["gt_alpha"][0] >= 0.996  # 254/255
+                # assign colors for fully opaque foreground
+                img_rgb = img[[2, 1, 0], ...].to(torch.float32) / 255.0
+                gt_fgr[:, mask] = img_rgb[:, mask]
+
+                data_sample["gt_foreground"] = gt_fgr
+                # fully opaque or fully transparent areas
+                data_sample["mask"] = (data_sample["gt_alpha"] >= 0.996) | (
+                    data_sample["gt_alpha"] == 0.0
+                )
+            data_sample["has_foreground"] = False
+
+        img_meta = {}
+        for key in self.meta_keys:
+            if key in results:
+                if isinstance(results[key], (int, float)):
+                    img_meta[key] = np.float32(results[key])
+                elif isinstance(results[key], np.ndarray):
+                    img_meta[key] = results[key].astype(np.float32)
+                else:
+                    img_meta[key] = results[key]
+        data_sample["meta"] = img_meta
+        packed_results["data_samples"] = data_sample
+
+        return packed_results
+
+    def __repr__(self) -> str:
+        repr_str = self.__class__.__name__
+        repr_str += f"(meta_keys={self.meta_keys})"
+        return repr_str
+
+
+@TRANSFORMS.register_module()
+class MattingRandomBackground(BaseTransform):
+    """Random background transform for alpha matting.
+
+    Composites the pre-multiplied foreground (`results["fgr"]`) over a random
+    background image in linear color space.
+
+    Args:
+        background_images_root (Union[str, List[str]]): Root directory or list of
+            directories containing background images.
+        prob (float): Probability of applying the transformation. Defaults to 0.5.
+    """
+
+    def __init__(
+        self,
+        background_images_root: Union[str, List[str]] = [],
+        prob: float = 0.5,
+    ):
+        super().__init__()
+
+        self.prob = prob
+        if isinstance(background_images_root, str):
+            background_images_root = [background_images_root]
+
+        self.background_images = []
+        for root in background_images_root:
+            self.background_images += [
+                os.path.join(root, image_name)
+                for image_name in os.listdir(root)
+                if image_name.endswith(".jpg") or image_name.endswith(".png")
+            ]
+
+    @staticmethod
+    def _srgb2linear(x: np.ndarray) -> np.ndarray:
+        return np.where(x <= 0.04045, x / 12.92, ((x + 0.055) / 1.055) ** 2.4)
+
+    @staticmethod
+    def _linear2srgb(x: np.ndarray) -> np.ndarray:
+        return np.where(x <= 0.0031308, 12.92 * x, 1.055 * x ** (1.0 / 2.4) - 0.055)
+
+    @staticmethod
+    def _resize_background(
+        background_image: np.ndarray, target_height: int, target_width: int
+    ) -> np.ndarray:
+        background_height, background_width = background_image.shape[:2]
+
+        # Resize to match target height while preserving aspect ratio
+        new_background_height = target_height
+        new_background_width = int(
+            new_background_height * background_width / background_height
+        )
+        background_image = cv2.resize(
+            background_image, (new_background_width, new_background_height)
+        )
+
+        # Center-crop to target width
+        if new_background_width > target_width:
+            start_x = (new_background_width - target_width) // 2
+            end_x = start_x + target_width
+            background_image = background_image[:, start_x:end_x]
+
+        # Final resize if dimensions don't match exactly
+        if (
+            background_image.shape[0] != target_height
+            or background_image.shape[1] != target_width
+        ):
+            background_image = cv2.resize(
+                background_image, (target_width, target_height)
+            )
+
+        return background_image
+
+    def _composite(
+        self, foreground: np.ndarray, background: np.ndarray, alpha: np.ndarray
+    ) -> np.ndarray:
+        fg_linear = self._srgb2linear(foreground / 255.0)
+        bg_linear = self._srgb2linear(background / 255.0)
+        composite_linear = fg_linear + (1 - alpha) * bg_linear
+        composite_srgb = self._linear2srgb(composite_linear)
+        return (composite_srgb * 255.0).astype(np.uint8)
+
+    def transform(self, results: dict) -> dict:
+        if random.random() > self.prob:
+            return results
+
+        image = results["fgr"]  # BGR image [0-255]
+        alpha = np.expand_dims(results["alpha"], -1)
+        image_height, image_width = image.shape[:2]
+
+        background_image_path = random.choice(self.background_images)
+
+        background_image = cv2.imread(background_image_path)
+        background_image = self._resize_background(
+            background_image, image_height, image_width
+        )
+
+        results["img"] = self._composite(image, background_image, alpha)
+
+        return results
+
+
+@TRANSFORMS.register_module()
+class MattingRandomJPEGCompression(BaseTransform):
+    """Simulate JPEG compression with random quality to introduce artifacts.
+
+    Args:
+        prob (float): Probability of applying the transform. Default 0.5.
+        quality_range (tuple[int, int]): The min and max compression quality.
+            Lower means heavier compression artifacts. E.g. (30, 60).
+    """
+
+    def __init__(self, prob=0.4, quality_range=(30, 60)):
+        super().__init__()
+        self.prob = prob
+        self.quality_range = quality_range
+
+    def transform(self, results: dict) -> dict:
+        if np.random.rand() > self.prob:
+            return results
+
+        img = results["img"]
+        q_min, q_max = self.quality_range
+        quality = np.random.randint(q_min, q_max + 1)
+
+        encode_param = [int(cv2.IMWRITE_JPEG_QUALITY), quality]
+        success, enc_img = cv2.imencode(".jpg", img, encode_param)
+        if success:
+            dec_img = cv2.imdecode(enc_img, cv2.IMREAD_COLOR)
+            results["img"] = dec_img
+        return results
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(prob={self.prob}, "
+            f"quality_range={self.quality_range})"
+        )
+
+
+@TRANSFORMS.register_module()
+class MattingCropAlphaBBox(BaseTransform):
+    """Crop image and related maps to the bounding box of the alpha mask.
+
+    This transform finds the bounding box of non-zero alpha regions and crops
+    the image, alpha, and foreground (if present) to that region.
+
+    Args:
+        threshold (float): Alpha threshold for determining foreground pixels.
+            Pixels with alpha >= threshold are considered foreground.
+            Defaults to 0.0 (any non-zero alpha).
+        padding_ratio (Tuple[float, float]): Range of random padding as a
+            percentage of bbox width (min_ratio, max_ratio). For example,
+            (0.0, 0.1) means padding will be randomly sampled between
+            0% and 10% of the bbox width. Defaults to (0.0, 0.0) (no padding).
+    """
+
+    def __init__(
+        self,
+        threshold: float = 0.0,
+        padding_ratio: Tuple[float, float] = (0.0, 0.1),
+        padding_color: float = 255.0,
+        prob: float = 0.5,
+    ):
+        super().__init__()
+        self.threshold = threshold
+        self.padding_ratio = padding_ratio
+        self.padding_color = padding_color
+        self.prob = prob
+
+    def _get_alpha_bbox(self, alpha: np.ndarray) -> Tuple[int, int, int, int]:
+        """Get bounding box of non-zero alpha region.
+
+        Args:
+            alpha: Alpha mask with values in [0, 1].
+
+        Returns:
+            Tuple of (x1, y1, x2, y2) defining the bounding box.
+        """
+        mask = alpha > self.threshold
+        rows = np.any(mask, axis=1)
+        cols = np.any(mask, axis=0)
+
+        if not np.any(rows) or not np.any(cols):
+            h, w = alpha.shape[:2]
+            return (0, 0, w, h)
+
+        y1, y2 = np.where(rows)[0][[0, -1]]
+        x1, x2 = np.where(cols)[0][[0, -1]]
+
+        y2 += 1
+        x2 += 1
+
+        return (x1, y1, x2, y2)
+
+    def _apply_padding(
+        self,
+        x1: int,
+        y1: int,
+        x2: int,
+        y2: int,
+        img_h: int,
+        img_w: int,
+    ) -> Tuple[int, int, int, int]:
+        """Apply random padding based on bbox width percentage."""
+        min_ratio, max_ratio = self.padding_ratio
+        if max_ratio <= 0:
+            return (x1, y1, x2, y2)
+
+        bbox_w = x2 - x1
+        ratio = random.uniform(min_ratio, max_ratio)
+        padding = int(bbox_w * ratio)
+
+        if padding > 0:
+            x1 = max(0, x1 - padding)
+            y1 = max(0, y1 - padding)
+            x2 = min(img_w, x2 + padding)
+            y2 = min(img_h, y2 + padding)
+
+        return (x1, y1, x2, y2)
+
+    def _pad_to_aspect_ratio(
+        self,
+        data: np.ndarray,
+        target_ar: float,
+        pad_value: float = 255.0,
+    ) -> np.ndarray:
+        """Pad data to match target aspect ratio (width/height).
+
+        Args:
+            data: Input array of shape (H, W) or (H, W, C).
+            target_ar: Target aspect ratio (width / height).
+            pad_value: Value to use for padding. Defaults to 1.0 (white).
+
+        Returns:
+            Padded array with the target aspect ratio.
+        """
+        h, w = data.shape[:2]
+        current_ar = w / h
+
+        if abs(current_ar - target_ar) < 1e-6:
+            return data
+
+        if current_ar < target_ar:
+            # Too tall, need to pad width
+            new_w = int(h * target_ar)
+            pad_total = new_w - w
+            pad_left = pad_total // 2
+
+            if data.ndim == 2:
+                padded = np.full((h, new_w), pad_value, dtype=data.dtype)
+                padded[:, pad_left : pad_left + w] = data
+            else:
+                c = data.shape[2]
+                padded = np.full((h, new_w, c), pad_value, dtype=data.dtype)
+                padded[:, pad_left : pad_left + w, :] = data
+        else:
+            # Too wide, need to pad height
+            new_h = int(w / target_ar)
+            pad_total = new_h - h
+            pad_top = pad_total // 2
+
+            if data.ndim == 2:
+                padded = np.full((new_h, w), pad_value, dtype=data.dtype)
+                padded[pad_top : pad_top + h, :] = data
+            else:
+                c = data.shape[2]
+                padded = np.full((new_h, w, c), pad_value, dtype=data.dtype)
+                padded[pad_top : pad_top + h, :, :] = data
+
+        return padded
+
+    def _crop(self, data: np.ndarray, bbox: Tuple[int, int, int, int]) -> np.ndarray:
+        """Crop data to bounding box."""
+        y1, y2, x1, x2 = bbox
+        return data[y1:y2, x1:x2, ...]
+
+    def transform(self, results: dict) -> dict:
+        if random.random() > self.prob:
+            return results
+
+        alpha = results["alpha"]
+        img = results["img"]
+        img_h, img_w = alpha.shape[:2]
+        target_ar = img_w / img_h
+
+        x1, y1, x2, y2 = self._get_alpha_bbox(alpha)
+        x1, y1, x2, y2 = self._apply_padding(x1, y1, x2, y2, img_h, img_w)
+        bbox = (y1, y2, x1, x2)  # Convert to crop format (y1, y2, x1, x2)
+
+        # Crop
+        cropped_img = self._crop(img, bbox)
+        cropped_alpha = self._crop(alpha, bbox)
+
+        results["img"] = self._pad_to_aspect_ratio(
+            cropped_img, target_ar, self.padding_color
+        )
+        results["alpha"] = self._pad_to_aspect_ratio(cropped_alpha, target_ar, 0.0)
+        results["img_shape"] = results["img"].shape[:2]
+
+        if "fgr" in results:
+            cropped_fgr = self._crop(results["fgr"], bbox)
+            results["fgr"] = self._pad_to_aspect_ratio(cropped_fgr, target_ar, 0.0)
+
+        return results
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(threshold={self.threshold}, "
+            f"padding_ratio={self.padding_ratio})"
+        )

--- a/sapiens/dense/src/evaluators/__init__.py
+++ b/sapiens/dense/src/evaluators/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .albedo_evaluator import AlbedoEvaluator
+from .matting_evaluator import MattingEvaluator
 from .normal_evaluator import NormalEvaluator
 from .pointmap_evaluator import PointmapEvaluator
 from .seg_evaluator import SegEvaluator
@@ -14,4 +15,5 @@ __all__ = [
     "SegEvaluator",
     "NormalEvaluator",
     "AlbedoEvaluator",
+    "MattingEvaluator",
 ]

--- a/sapiens/dense/src/evaluators/matting_evaluator.py
+++ b/sapiens/dense/src/evaluators/matting_evaluator.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+
+import torch
+import torch.nn.functional as F
+from prettytable import PrettyTable
+from sapiens.engine.evaluators import BaseEvaluator
+from sapiens.registry import MODELS
+
+
+@MODELS.register_module()
+class MattingEvaluator(BaseEvaluator):
+    def __init__(self):
+        super().__init__()
+
+    @torch.no_grad()
+    def process(self, predictions: torch.Tensor, data_samples: dict, accelerator=None):
+        """
+        Args:
+            predictions: Tensor, predicted albedo (B, 3, H_low, W_low)
+            data_samples: dict with keys:
+                - "gt_alpha": (B, 1, H, W)
+                - "gt_foreground": (B, 3, H, W) optional
+        """
+        assert accelerator is not None, "evaluation process expects an accelerator"
+
+        gt_alphas = data_samples["gt_alpha"]  # (B,1,H,W)
+        gt_foregrounds = data_samples.get("gt_foreground", None)  # (B,3,H,W)
+        has_foregrounds = data_samples["has_foreground"]
+
+        # Align spatial size
+        if predictions.shape[2:] != gt_alphas.shape[2:]:
+            predictions = F.interpolate(
+                input=predictions,
+                size=gt_alphas.shape[2:],
+                mode="bilinear",
+                align_corners=False,
+            )
+
+        pred_alphas = predictions[:, -1:, :, :]  # [B, 1, H, W]
+        pred_foregrounds = (
+            predictions[:, :3, :, :] if predictions.shape[1] == 4 else None
+        )  # [B, 3, H, W]
+
+        B = predictions.shape[0]
+        per_sample_vecs = []  # each: [l1_pha, N_pha, l1_fgr, N_fgr]
+
+        for i in range(B):
+            gt_alpha = gt_alphas[i][0]  # (H,W)
+            pred_alpha = pred_alphas[i][0]  # (H,W)
+
+            # --- Pixel MAE / RMSE accumulators (average over channels per pixel) ---
+            l1_pha = (gt_alpha - pred_alpha).abs()
+            sum_l1_pha = l1_pha.to(torch.float64).sum().unsqueeze(0)  # (1,)
+            N_pha = torch.tensor(
+                [float(gt_alpha.numel())], dtype=torch.float64, device=pred_alpha.device
+            )
+
+            if has_foregrounds[i]:
+                gt_foreground = gt_foregrounds[i]  # (3,H,W)
+                pred_foreground = pred_foregrounds[i]  # (3,H,W)
+
+                diff_fgr = gt_foreground - pred_foreground  # (3,H,W)
+                l1_fgr = diff_fgr.abs().mean(dim=0)  # (H,W)
+                sum_l1_fgr = l1_fgr.to(torch.float64).sum().unsqueeze(0)  # (1,)
+                N_fgr = N_pha.clone()
+            else:
+                sum_l1_fgr = torch.tensor(
+                    [0], dtype=torch.float64, device=pred_alpha.device
+                )
+                N_fgr = torch.tensor([0], dtype=torch.float64, device=pred_alpha.device)
+
+            vec = torch.cat([sum_l1_pha, N_pha, sum_l1_fgr, N_fgr], dim=0)
+            per_sample_vecs.append(vec)
+
+        pack = torch.stack(per_sample_vecs, dim=0)  # (B_local, 4)
+        gpack = accelerator.gather_for_metrics(pack)  # (B_global_step, 4)
+        step_totals = gpack.sum(dim=0)  # (4,)
+
+        if accelerator.is_main_process:
+            self.results.append(step_totals)
+        return
+
+    def evaluate(self, logger=None, accelerator=None) -> Dict[str, float]:
+        """
+        Returns:
+            Dict[str, float]: {
+                'l1_alpha', 'l1_foreground'
+            }
+        """
+        assert accelerator is not None, "evaluation aggregation expects an accelerator"
+
+        if not accelerator.is_main_process:
+            self.reset()
+            return {}
+
+        if not self.results:
+            if logger is not None:
+                logger.info("No results to evaluate.")
+            return {}
+
+        totals = torch.stack(self.results, dim=0).sum(dim=0)  # (4,)
+        sum_l1_pha, N_pha, sum_l1_fgr, N_fgr = totals
+
+        metrics: Dict[str, float] = {}
+        if N_pha.item() > 0:
+            metrics["l1_alpha"] = float((sum_l1_pha / N_pha).item())
+        if N_fgr.item() > 0:
+            metrics["l1_foreground"] = float((sum_l1_fgr / N_fgr).item())
+
+        table = PrettyTable()
+        table.field_names = list(metrics.keys())
+        table.add_row([f"{float(v):.5f}" for v in metrics.values()])
+        if logger is not None:
+            logger.info("\n" + table.get_string())
+
+        self.reset()
+        return metrics

--- a/sapiens/dense/src/models/core/__init__.py
+++ b/sapiens/dense/src/models/core/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .albedo_estimator import AlbedoEstimator
+from .matting_estimator import MattingEstimator
 from .normal_estimator import NormalEstimator
 from .pointmap_estimator import PointmapEstimator
 from .seg_estimator import SegEstimator
@@ -14,4 +15,5 @@ __all__ = [
     "SegEstimator",
     "NormalEstimator",
     "AlbedoEstimator",
+    "MattingEstimator",
 ]

--- a/sapiens/dense/src/models/core/matting_estimator.py
+++ b/sapiens/dense/src/models/core/matting_estimator.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple, Union
+
+import torch
+from sapiens.engine.models import BaseModel
+from sapiens.registry import MODELS
+from torch import Tensor
+
+
+@MODELS.register_module()
+class MattingEstimator(BaseModel):
+    def __init__(
+        self,
+        backbone: dict = None,
+        decode_head: dict = None,
+        init_cfg: dict = None,
+    ):
+        BaseModel.__init__(self, init_cfg=init_cfg)
+        self.backbone = MODELS.build(backbone)
+        self.decode_head = MODELS.build(decode_head)
+
+        ## Load init weights
+        self.init_weights()
+
+    def loss(
+        self, outputs: Union[Tensor, Tuple[Tensor, ...]], data_samples: dict
+    ) -> Tuple[dict, Tensor]:
+        losses, fgr_pha = self.decode_head.loss(outputs, data_samples)
+        parsed_losses, log_vars = self.parse_losses(losses)
+        log_vars["outputs"] = fgr_pha
+        return parsed_losses, log_vars
+
+    def forward(self, inputs: Tensor) -> Tensor:
+        ## backbone forward returns a list of tensors at different depths, 0 is the final layer
+        if self.training:
+            x = torch.utils.checkpoint.checkpoint(
+                self.backbone, inputs, use_reentrant=False
+            )[0]
+        else:
+            x = self.backbone(inputs)[0]
+
+        x = self.decode_head(x)  ## B x out_channels x H x W
+        return x

--- a/sapiens/dense/src/models/heads/__init__.py
+++ b/sapiens/dense/src/models/heads/__init__.py
@@ -5,8 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from .albedo_head import AlbedoHead
+from .matting_head import MattingHead
 from .normal_head import NormalHead
 from .pointmap_head import PointmapHead
 from .seg_head import SegHead
 
-__all__ = ["PointmapHead", "SegHead", "NormalHead", "AlbedoHead"]
+__all__ = ["PointmapHead", "SegHead", "NormalHead", "AlbedoHead", "MattingHead"]

--- a/sapiens/dense/src/models/heads/matting_head.py
+++ b/sapiens/dense/src/models/heads/matting_head.py
@@ -1,0 +1,176 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from sapiens.registry import MODELS
+
+
+@MODELS.register_module()
+class MattingHead(nn.Module):
+    def __init__(
+        self,
+        in_channels: int = 768,
+        upsample_channels: List[int] = [768, 384, 192, 96],
+        conv_out_channels: Optional[Sequence[int]] = None,
+        conv_kernel_sizes: Optional[Sequence[int]] = None,
+        out_channels: int = 1,
+        loss_decode=dict(type="L1Loss", loss_weight=1.0),
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.in_channels = in_channels
+        self._build_network(upsample_channels, conv_out_channels, conv_kernel_sizes)
+        in_channels = (
+            conv_out_channels[-1] if conv_out_channels else upsample_channels[-1]
+        )
+        self.conv_matting = nn.Conv2d(in_channels, out_channels, kernel_size=1)
+
+        if isinstance(loss_decode, dict):
+            self.loss_decode = MODELS.build(loss_decode)
+        elif isinstance(loss_decode, (list, tuple)):
+            self.loss_decode = nn.ModuleList()
+            for loss in loss_decode:
+                self.loss_decode.append(MODELS.build(loss))
+        else:
+            raise TypeError(
+                f"loss_decode must be a dict or sequence of dict,\
+                but got {type(loss_decode)}"
+            )
+
+        self._init_weights()
+
+    def _build_network(
+        self,
+        upsample_channels: List[int],
+        conv_out_channels: Optional[Sequence[int]],
+        conv_kernel_sizes: Optional[Sequence[int]],
+    ) -> None:
+        in_channels = self.in_channels
+
+        self.input_conv = nn.Sequential(
+            nn.Conv2d(in_channels, in_channels, kernel_size=3, padding=1),
+            nn.InstanceNorm2d(in_channels),  # Normalize first
+            nn.SiLU(inplace=True),
+        )
+
+        # Progressive upsampling blocks
+        up_blocks = []
+        cur_ch = in_channels
+        for out_ch in upsample_channels:
+            up_blocks.append(
+                nn.Sequential(
+                    nn.Conv2d(cur_ch, out_ch * 4, kernel_size=3, padding=1),
+                    nn.PixelShuffle(2),  # ↑ spatial ×2
+                    nn.InstanceNorm2d(out_ch),
+                    nn.SiLU(inplace=True),
+                )
+            )
+
+            cur_ch = out_ch
+        self.upsample_blocks = nn.Sequential(*up_blocks)
+
+        # optional extra conv layers
+        conv_layers = []
+        if conv_out_channels and conv_kernel_sizes:
+            for out_ch, k in zip(conv_out_channels, conv_kernel_sizes):
+                conv_layers.extend(
+                    [
+                        nn.Conv2d(cur_ch, out_ch, k, padding=(k - 1) // 2),
+                        nn.InstanceNorm2d(out_ch),
+                        nn.SiLU(inplace=True),
+                    ]
+                )
+                cur_ch = out_ch
+
+        self.conv_layers = nn.Sequential(*conv_layers)
+
+    def _init_weights(self) -> None:
+        """Initialize network weights."""
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                weight_dtype = m.weight.dtype
+                weight = nn.init.kaiming_normal_(
+                    m.weight.float(), mode="fan_out", nonlinearity="relu"
+                )
+                m.weight.data = weight.to(weight_dtype)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.Linear):
+                weight_dtype = m.weight.dtype
+                weight = nn.init.kaiming_normal_(
+                    m.weight.float(), mode="fan_in", nonlinearity="linear"
+                )
+                m.weight.data = weight.to(weight_dtype)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+
+    def forward(self, x: Union[torch.Tensor, Tuple[torch.Tensor]]) -> torch.Tensor:
+        x = self.input_conv(x)
+        x = self.upsample_blocks(x)
+        x = self.conv_layers(x)
+        out = self.conv_matting(x)
+        return out.sigmoid()
+
+    def loss(
+        self,
+        outputs: torch.Tensor,
+        data_samples: dict,
+    ) -> dict:
+        gt_alpha = data_samples["gt_alpha"]
+        gt_foreground = data_samples["gt_foreground"]
+        valid_mask = data_samples["mask"]
+
+        if outputs.shape[2:] != gt_alpha.shape[2:]:
+            outputs = F.interpolate(
+                input=outputs,
+                size=gt_alpha.shape[2:],
+                mode="bilinear",
+                align_corners=False,
+            )
+
+        # output could be rgba or alpha only
+        pred_alpha = outputs[:, -1:, :, :]  ## [B, 1, H, W]
+        pred_foreground = outputs[:, :3, :, :] if outputs.shape[1] == 4 else None
+
+        loss = dict()
+
+        if not isinstance(self.loss_decode, nn.ModuleList):
+            losses_decode = [self.loss_decode]
+        else:
+            losses_decode = self.loss_decode
+
+        def _accumulate_loss(
+            loss_dict: Dict[str, Any],
+            key: str,
+            value: Any,
+        ) -> None:
+            if key in loss_dict:
+                loss_dict[key] += value
+            else:
+                loss_dict[key] = value
+
+        for loss_decode in losses_decode:
+            loss_name = loss_decode.loss_name
+            # Alpha loss
+            _accumulate_loss(
+                loss,
+                loss_name + "_pha",
+                loss_decode(pred_alpha, gt_alpha),
+            )
+            # Foreground loss - some data may not have GT foreground,
+            # so we use mask to skip the loss calculation for semi-transparent areas
+            if pred_foreground is not None:
+                _accumulate_loss(
+                    loss,
+                    loss_name + "_fgr",
+                    loss_decode(pred_foreground, gt_foreground, valid_mask=valid_mask),
+                )
+
+        return loss, outputs

--- a/sapiens/dense/src/models/losses/__init__.py
+++ b/sapiens/dense/src/models/losses/__init__.py
@@ -6,6 +6,7 @@
 
 from .albedo_loss import AlbedoGradL1Loss
 from .l1_loss import L1Loss
+from .matting_loss import MattingGradLoss, MattingL1Loss, MattingLaplacianLoss
 from .normal_loss import NormalCosineSimilarityLoss, NormalGradL1Loss
 from .pointmap_loss import (
     PointmapIntrinsicsConsistencyLoss,
@@ -28,4 +29,7 @@ __all__ = [
     "NormalCosineSimilarityLoss",
     "NormalGradL1Loss",
     "AlbedoGradL1Loss",
+    "MattingL1Loss",
+    "MattingGradLoss",
+    "MattingLaplacianLoss",
 ]

--- a/sapiens/dense/src/models/losses/matting_loss.py
+++ b/sapiens/dense/src/models/losses/matting_loss.py
@@ -1,0 +1,704 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
+
+import logging
+from functools import lru_cache
+from typing import Any
+
+import cv2
+import numpy as np
+import numpy.typing as npt
+import scipy.sparse as sp_sparse
+import scipy.sparse.linalg as sp_linalg
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from sapiens.registry import MODELS  # pyre-ignore[21]
+from torch import Tensor
+
+from .utils import weight_reduce_loss
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class BaseMattingLoss(nn.Module):
+    """Base class for all Matting loss functions."""
+
+    def __init__(self, loss_name: str, loss_weight: float) -> None:
+        super().__init__()
+        self._loss_name = loss_name
+        self._loss_weight = loss_weight
+
+    @property
+    def loss_name(self) -> str:
+        """Returns the name of this loss function."""
+        return self._loss_name
+
+
+@MODELS.register_module()
+class MattingL1Loss(BaseMattingLoss):
+    def __init__(
+        self,
+        reduction: str = "mean",
+        loss_weight: float = 1.0,
+        eps: float = -100,
+        loss_name: str = "loss_l1",
+    ) -> None:
+        super().__init__(loss_name, loss_weight)
+        self.reduction = reduction
+        self.eps = eps
+
+    def forward(
+        self,
+        pred: Tensor,
+        target: Tensor,
+        valid_mask: Tensor | None = None,
+        weight: Tensor | None = None,
+        avg_factor: int | None = None,
+        reduction_override: str | None = None,
+    ) -> Tensor:
+        assert pred.shape == target.shape, (
+            f"The shapes of pred ({pred.shape}) and target ({target.shape}) are mismatched"
+        )
+        assert reduction_override in (
+            None,
+            "none",
+            "mean",
+            "sum",
+        ), "Invalid reduction_override value"
+        if valid_mask is not None and valid_mask.sum() == 0:
+            return torch.tensor(0, dtype=pred.dtype, device=pred.device)
+        reduction = reduction_override if reduction_override else self.reduction
+
+        loss = F.l1_loss(pred, target, reduction="none")  # B x C x H x W
+        if valid_mask is not None:
+            loss *= valid_mask
+
+        loss = (
+            weight_reduce_loss(loss, weight, reduction, avg_factor) * self._loss_weight
+        )
+
+        # Convert nan to 0
+        # torch.nan_to_num expects nan, posinf, neginf as Number
+        loss = torch.nan_to_num(
+            loss,
+            nan=0.0,
+            posinf=0.0,
+            neginf=0.0,
+        )
+
+        return loss
+
+
+def compute_sobel_gradients(x: Tensor) -> tuple[Tensor, Tensor]:
+    # Sobel kernels
+    sobel_x = torch.tensor(
+        [[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]], dtype=x.dtype, device=x.device
+    ).view(1, 1, 3, 3)
+    sobel_y = torch.tensor(
+        [[-1, -2, -1], [0, 0, 0], [1, 2, 1]], dtype=x.dtype, device=x.device
+    ).view(1, 1, 3, 3)
+
+    B, C, H, W = x.shape
+    x = x.reshape(B * C, 1, H, W)
+
+    # Apply padding to maintain size
+    x_pad = F.pad(x, (1, 1, 1, 1), mode="reflect")
+
+    # Compute gradients using Sobel filters
+    grad_x = F.conv2d(x_pad, sobel_x, padding=0)
+    grad_y = F.conv2d(x_pad, sobel_y, padding=0)
+
+    grad_x = grad_x.reshape(B, C, H, W)
+    grad_y = grad_y.reshape(B, C, H, W)
+
+    return grad_x, grad_y
+
+
+@MODELS.register_module()
+class MattingGradLoss(BaseMattingLoss):
+    def __init__(
+        self,
+        reduction: str = "mean",
+        loss_weight: float = 1.0,
+        loss_name: str = "loss_grad",
+    ) -> None:
+        super().__init__(loss_name, loss_weight)
+        self.reduction = reduction
+
+    def forward(
+        self,
+        pred: Tensor,
+        target: Tensor,
+        valid_mask: Tensor | None = None,
+        weight: Tensor | None = None,
+        avg_factor: int | None = None,
+        reduction_override: str | None = None,
+    ) -> Tensor:
+        assert pred.shape == target.shape, (
+            f"The shapes of pred ({pred.shape}) and target ({target.shape}) are mismatched"
+        )
+        assert reduction_override in (
+            None,
+            "none",
+            "mean",
+            "sum",
+        ), "Invalid reduction_override value"
+        if valid_mask is not None and valid_mask.sum() == 0:
+            return torch.tensor(0, dtype=pred.dtype, device=pred.device)
+
+        reduction = reduction_override if reduction_override else self.reduction
+
+        pred_grad_x, pred_grad_y = compute_sobel_gradients(pred)
+        gt_grad_x, gt_grad_y = compute_sobel_gradients(target)
+        pred_grad_mag = torch.sqrt(pred_grad_x.pow(2) + pred_grad_y.pow(2) + 1e-6)
+        gt_grad_mag = torch.sqrt(gt_grad_x.pow(2) + gt_grad_y.pow(2) + 1e-6)
+
+        loss_grad = F.l1_loss(pred_grad_mag, gt_grad_mag, reduction="none")
+        if valid_mask is not None:
+            loss_grad *= valid_mask
+
+        loss = (
+            weight_reduce_loss(loss_grad, weight, reduction, avg_factor)
+            * self._loss_weight
+        )
+
+        return loss
+
+
+@lru_cache(maxsize=1000)
+def gauss_kernel(
+    device: torch.device | str = "cpu", dtype: torch.dtype = torch.float32
+) -> Tensor:
+    kernel = torch.tensor(
+        [
+            [1, 4, 6, 4, 1],
+            [4, 16, 24, 16, 4],
+            [6, 24, 36, 24, 6],
+            [4, 16, 24, 16, 4],
+            [1, 4, 6, 4, 1],
+        ],
+        device=device,
+        dtype=dtype,
+    )
+    kernel /= 256
+    kernel = kernel[None, None, :, :]
+    return kernel
+
+
+def laplacian_loss(
+    pred: Tensor,
+    target: Tensor,
+    max_levels: int,
+    reduction: str,
+    valid_mask: Tensor | None = None,
+) -> Tensor:
+    pred_pyramid = laplacian_pyramid(pred, max_levels)
+    target_pyramid = laplacian_pyramid(target, max_levels)
+    loss: Tensor = torch.tensor(0.0, device=pred.device, dtype=pred.dtype)
+    for level in range(max_levels):
+        if valid_mask is not None:
+            mask = F.interpolate(
+                input=valid_mask.float(),
+                size=pred_pyramid[level].shape[2:],
+                mode="nearest",
+            )
+
+            loss += (2**level) * F.l1_loss(
+                pred_pyramid[level] * mask,
+                target_pyramid[level] * mask,
+                reduction=reduction,
+            )
+        else:
+            loss += (2**level) * F.l1_loss(
+                pred_pyramid[level], target_pyramid[level], reduction=reduction
+            )
+
+    if reduction == "mean":
+        loss = loss / max_levels
+    return loss
+
+
+def laplacian_pyramid(img: Tensor, max_levels: int) -> list[Tensor]:
+    kernel = gauss_kernel(device=img.device, dtype=img.dtype)
+    current = img
+    pyramid: list[Tensor] = []
+    for _ in range(max_levels - 1):
+        current = crop_to_even_size(current)
+        down = downsample(current, kernel)
+        up = upsample(down, kernel)
+        diff = current - up
+        pyramid.append(diff)
+        current = down
+    # Append the top level of the pyramid (the final non-difference level)
+    pyramid.append(current)
+    return pyramid
+
+
+def gauss_convolution(img: Tensor, kernel: Tensor) -> Tensor:
+    B, C, H, W = img.shape
+    img = img.reshape(B * C, 1, H, W)
+    img = F.pad(img, (2, 2, 2, 2), mode="reflect")
+    img = F.conv2d(img, kernel)
+    img = img.reshape(B, C, H, W)
+    return img
+
+
+def downsample(img: Tensor, kernel: Tensor) -> Tensor:
+    img = gauss_convolution(img, kernel)
+    img = img[:, :, ::2, ::2]
+    return img
+
+
+def upsample(img: Tensor, kernel: Tensor) -> Tensor:
+    B, C, H, W = img.shape
+    out = torch.zeros((B, C, H * 2, W * 2), device=img.device, dtype=img.dtype)
+    out[:, :, ::2, ::2] = img * 4
+    out = gauss_convolution(out, kernel)
+    return out
+
+
+def crop_to_even_size(img: Tensor) -> Tensor:
+    H, W = img.shape[2:]
+    H = H - H % 2
+    W = W - W % 2
+    return img[:, :, :H, :W]
+
+
+@MODELS.register_module()
+class MattingLaplacianLoss(BaseMattingLoss):
+    def __init__(
+        self,
+        max_levels: int = 5,
+        reduction: str = "mean",
+        loss_weight: float = 1.0,
+        loss_name: str = "loss_lap",
+    ) -> None:
+        super().__init__(loss_name, loss_weight)
+        self.max_levels = max_levels
+        self.reduction = reduction
+
+    def forward(
+        self,
+        pred: Tensor,
+        target: Tensor,
+        valid_mask: Tensor | None = None,
+        weight: Tensor | None = None,
+        avg_factor: int | None = None,
+        reduction_override: str | None = None,
+    ) -> Tensor:
+        assert pred.shape == target.shape, (
+            f"The shapes of pred ({pred.shape}) and target ({target.shape}) are mismatched"
+        )
+        assert reduction_override in (
+            None,
+            "none",
+            "mean",
+            "sum",
+        ), "Invalid reduction_override value"
+        if valid_mask is not None and valid_mask.sum() == 0:
+            return torch.tensor(0, dtype=pred.dtype, device=pred.device)
+
+        reduction = reduction_override if reduction_override else self.reduction
+
+        loss = laplacian_loss(
+            pred,
+            target,
+            valid_mask=valid_mask,
+            max_levels=self.max_levels,
+            reduction=reduction,
+        )
+
+        loss = (
+            weight_reduce_loss(loss, weight, reduction, avg_factor) * self._loss_weight
+        )
+
+        return loss
+
+
+def compute_rolling_block(
+    A: npt.NDArray[np.int_], block: tuple[int, int] = (3, 3)
+) -> npt.NDArray[np.int_]:
+    """Compute rolling blocks of a 2D array.
+
+    Args:
+        A: Input 2D array
+        block: Block size as (height, width)
+
+    Returns:
+        Array of rolling blocks
+    """
+    shape = ((A.shape[0] - block[0] + 1), (A.shape[1] - block[1] + 1)) + block
+    strides = (A.strides[0], A.strides[1]) + A.strides
+    return np.lib.stride_tricks.as_strided(A, shape=shape, strides=strides)
+
+
+def prepare_window_indices(
+    index_matrix: npt.NDArray[np.int_],
+    height: int,
+    width: int,
+    window_radius: int,
+) -> tuple[npt.NDArray[np.int_], int, int]:
+    """Prepare window indices for the matting Laplacian.
+
+    Args:
+        index_matrix: Matrix of flattened indices
+        height: Image height
+        width: Image width
+        window_radius: Radius of the local window
+
+    Returns:
+        Window indices array
+    """
+    window_diameter = 2 * window_radius + 1
+    window_size = window_diameter**2
+
+    # Number of valid window center positions
+    center_height = height - 2 * window_radius
+    center_width = width - 2 * window_radius
+
+    # Extract sliding window indices
+    window_indices = compute_rolling_block(
+        index_matrix, block=(window_diameter, window_diameter)
+    )
+    window_indices = window_indices.reshape(center_height, center_width, window_size)
+    return window_indices, window_size, window_diameter
+
+
+def apply_mask_to_windows(
+    indices: npt.NDArray[np.int_],
+    mask: npt.NDArray[np.uint8] | None,
+    diameter: int,
+) -> npt.NDArray[np.int_]:
+    """Apply mask to window indices if provided.
+
+    Args:
+        indices: Array of window indices
+        mask: Binary mask
+        diameter: Diameter of the window
+
+    Returns:
+        Masked window indices
+    """
+    if mask is not None:
+        dilated_mask = cv2.dilate(
+            mask.astype(np.uint8), np.ones((diameter, diameter), np.uint8)
+        ).astype(np.bool_)
+        window_mask_sum = np.sum(dilated_mask.ravel()[indices], axis=2)
+        return indices[window_mask_sum > 0, :]
+    else:
+        return indices.reshape(-1, indices.shape[-1])
+
+
+def compute_window_statistics(
+    window_values: npt.NDArray[np.floating[Any]],
+    window_size: int,
+    eps: float,
+    num_channels: int,
+) -> tuple[npt.NDArray[np.floating[Any]], npt.NDArray[np.floating[Any]]]:
+    """Compute statistics for each window.
+
+    Args:
+        window_values: Image values within each window
+        window_size: Size of each window
+        eps: Regularization parameter
+        num_channels: Number of image channels
+
+    Returns:
+        Window statistics needed for Laplacian computation
+    """
+    # Compute window statistics
+    window_mean = np.mean(window_values, axis=1, keepdims=True)
+    window_covariance = (
+        window_values.swapaxes(-2, -1) @ window_values
+    ) / window_size - (window_mean.swapaxes(-2, -1) @ window_mean)
+
+    # Compute inverse of regularized covariance
+    regularizer = (eps / window_size) * np.eye(num_channels)
+    covariance_inv = np.linalg.inv(window_covariance + regularizer)
+
+    return window_mean, covariance_inv
+
+
+def compute_laplacian_values(
+    window_values: npt.NDArray[np.floating[Any]],
+    window_mean: npt.NDArray[np.floating[Any]],
+    covariance_inv: npt.NDArray[np.floating[Any]],
+    window_size: int,
+) -> npt.NDArray[np.floating[Any]]:
+    """Compute Laplacian values for each window.
+
+    Args:
+        window_values: Image values within each window
+        window_mean: Mean of each window
+        covariance_inv: Inverse of regularized covariance
+        window_size: Size of each window
+
+    Returns:
+        Laplacian values
+    """
+    centered_values = window_values - window_mean
+    transformed = centered_values @ covariance_inv
+    return np.eye(window_size) - (1.0 / window_size) * (
+        1 + transformed @ centered_values.transpose(0, 2, 1)
+    )
+
+
+def create_sparse_tensor(
+    window_indices: npt.NDArray[np.int_],
+    laplacian_values: npt.NDArray[np.floating[Any]],
+    height: int,
+    width: int,
+) -> torch.Tensor:
+    """Create sparse COO tensor from Laplacian values.
+
+    Args:
+        window_indices: Array of window indices
+        laplacian_values: Computed Laplacian values
+        height: Image height
+        width: Image width
+
+    Returns:
+        Sparse COO tensor
+    """
+    window_size = window_indices.shape[1]
+    # Build sparse matrix indices
+    col_indices = np.tile(window_indices, window_size).ravel()
+    row_indices = np.repeat(window_indices, window_size).ravel()
+    values = laplacian_values.ravel()
+
+    # Create sparse COO tensor
+    indices = torch.tensor(np.stack([row_indices, col_indices]), dtype=torch.long)
+    sparse_values = torch.tensor(values, dtype=torch.float32)
+    return torch.sparse_coo_tensor(
+        indices, sparse_values, size=(height * width, height * width)
+    )
+
+
+def compute_matting_laplacian(
+    image: npt.NDArray[np.floating[Any]],
+    mask: npt.NDArray[np.uint8] | None = None,
+    eps: float = 1e-7,
+    window_radius: int = 1,
+) -> torch.Tensor:
+    """Compute the Matting Laplacian matrix for a given image.
+
+    This implements the closed-form matting Laplacian from:
+    "A Closed Form Solution to Natural Image Matting" by Levin et al.
+
+    Args:
+        image: Input image array of shape (H, W, C) with C channels (typically 3).
+        mask: Optional binary mask of shape (H, W). If provided, the Laplacian
+            is computed only for pixels where mask is True. If None, computed
+            for all pixels.
+        eps: Regularization parameter controlling alpha smoothness.
+            Corresponds to epsilon in Eq. 12 of the paper.
+        window_radius: Radius of the local window used to build the Laplacian.
+            Window size will be (2 * window_radius + 1)^2.
+
+    Returns:
+        Sparse COO tensor of shape (H*W, H*W) holding the Matting Laplacian.
+    """
+    height, width, num_channels = image.shape
+
+    # Create index matrix and flatten image
+    index_matrix = np.arange(height * width).reshape((height, width))
+    flat_image = image.reshape(height * width, num_channels)
+
+    # Prepare window indices
+    window_indices, window_size, window_diameter = prepare_window_indices(
+        index_matrix, height, width, window_radius
+    )
+
+    # Apply mask if provided
+    window_indices = apply_mask_to_windows(window_indices, mask, window_diameter)
+
+    # Get image values within each window: (num_windows, window_size, num_channels)
+    window_values = flat_image[window_indices]
+
+    # Compute window statistics
+    window_mean, covariance_inv = compute_window_statistics(
+        window_values, window_size, eps, num_channels
+    )
+
+    # Compute Laplacian values
+    laplacian_values = compute_laplacian_values(
+        window_values, window_mean, covariance_inv, window_size
+    )
+
+    # Create sparse tensor
+    return create_sparse_tensor(window_indices, laplacian_values, height, width)
+
+
+def scipy_sparse_to_torch_sparse(
+    sparse_matrix: Any,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Convert scipy sparse COO matrix to PyTorch sparse tensor."""
+    # Ensure COO format
+    coo = sparse_matrix.tocoo()
+    # Create indices tensor (2 x nnz)
+    indices = torch.tensor(
+        [coo.row, coo.col],
+        dtype=torch.long,
+        device=device,
+    )
+    # Create values tensor
+    values = torch.tensor(
+        coo.data,
+        dtype=dtype,
+        device=device,
+    )
+    # Create sparse tensor
+    sparse_tensor = torch.sparse_coo_tensor(
+        indices,
+        values,
+        size=coo.shape,
+        device=device,
+        dtype=dtype,
+    )
+    return sparse_tensor
+
+
+def closed_form_matting_with_prior(
+    image: npt.NDArray[np.floating[Any]],
+    prior: npt.NDArray[np.floating[Any]],
+    prior_confidence: npt.NDArray[np.floating[Any]],
+    consts_map: npt.NDArray[np.bool_] | None = None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Applies closed form matting with prior alpha map to image.
+
+    Args:
+        image: 3-dim numpy matrix with input image of shape (H, W, C).
+        prior: matrix of same width and height as input image holding apriori alpha map.
+        prior_confidence: matrix of the same shape as prior holding confidence of prior alpha.
+        consts_map: binary mask of pixels that aren't expected to change due to high
+            prior confidence.
+
+    Returns:
+        2-dim matrix holding computed alpha map.
+    """
+    assert image.shape[:2] == prior.shape, (
+        "prior must be 2D matrix with height and width equal to image."
+    )
+    assert image.shape[:2] == prior_confidence.shape, (
+        "prior_confidence must be 2D matrix with height and width equal to image."
+    )
+    if consts_map is not None:
+        assert image.shape[:2] == consts_map.shape, (
+            "consts_map must be 2D matrix with height and width equal to image."
+        )
+
+    logger.info("Computing Matting Laplacian.")
+    laplacian = compute_matting_laplacian(
+        image, ~consts_map if consts_map is not None else None
+    )
+
+    # Convert sparse torch tensor to scipy sparse for solving
+    laplacian_np = laplacian.coalesce()
+    indices = laplacian_np.indices().cpu().numpy()
+    values = laplacian_np.values().cpu().numpy()
+    laplacian_scipy = sp_sparse.coo_matrix(
+        (values, (indices[0], indices[1])), shape=laplacian_np.shape
+    ).tocsr()
+
+    confidence = sp_sparse.diags(prior_confidence.ravel())
+    logger.info("Solving for alpha.")
+    solution = sp_linalg.spsolve(
+        laplacian_scipy + confidence, prior.ravel() * prior_confidence.ravel()
+    )
+    alpha = np.minimum(np.maximum(solution.reshape(prior.shape), 0), 1)
+    return alpha
+
+
+def closed_form_matting_with_trimap(
+    image: npt.NDArray[np.floating[Any]],
+    trimap: npt.NDArray[np.floating[Any]],
+    trimap_confidence: float = 100.0,
+) -> npt.NDArray[np.floating[Any]]:
+    """Apply Closed-Form matting to given image using trimap.
+
+    Args:
+        image: Input image of shape (H, W, C).
+        trimap: Trimap of shape (H, W) with values in [0, 1].
+        trimap_confidence: Confidence value for trimap constraints.
+
+    Returns:
+        Computed alpha matte of shape (H, W).
+    """
+    assert image.shape[:2] == trimap.shape, (
+        "trimap must be 2D matrix with height and width equal to image."
+    )
+    consts_map = (trimap < 0.1) | (trimap > 0.9)
+    return closed_form_matting_with_prior(
+        image, trimap, trimap_confidence * consts_map, consts_map
+    )
+
+
+@MODELS.register_module()
+class MattingNaturalImageLaplacianLoss(BaseMattingLoss):
+    def __init__(
+        self,
+        reduction: str = "mean",
+        loss_weight: float = 1.0,
+        loss_name: str = "loss_natural_image_lap",
+    ) -> None:
+        super().__init__(loss_name, loss_weight)
+        self.reduction = reduction
+
+    def forward(
+        self,
+        pred: Tensor,
+        image: Tensor,
+        valid_mask: Tensor | None = None,
+        weight: Tensor | None = None,
+    ) -> Tensor:
+        """Compute the natural image matting Laplacian loss.
+
+        Args:
+            pred: Predicted alpha matte of shape (H, W) or (H, W, 1).
+                Must be single-channel as the Laplacian loss operates on alpha values.
+            image: Input RGB image of shape (H, W, C) used to compute the Laplacian.
+                The Laplacian encodes color-based smoothness constraints.
+            valid_mask: Optional mask of shape (H, W) or (H, W, 1).
+            weight: Unused, kept for API consistency.
+
+        Returns:
+            Scalar loss value: alpha^T @ L @ alpha
+        """
+        # Ensure pred is 2D (H, W) for the Laplacian computation
+        if pred.dim() == 3:
+            if pred.shape[-1] == 1:
+                pred = pred.squeeze(-1)
+            else:
+                raise ValueError(
+                    f"pred must be single-channel (H, W) or (H, W, 1), got {pred.shape}"
+                )
+
+        height, width = pred.shape
+        assert image.shape[0] == height and image.shape[1] == width, (
+            f"Spatial dimensions of pred ({pred.shape}) and image ({image.shape}) must match"
+        )
+
+        if valid_mask is not None and valid_mask.sum() == 0:
+            return torch.tensor(0, dtype=pred.dtype, device=pred.device)
+
+        # Convert to numpy and compute Laplacian
+        image_np = image.detach().cpu().numpy()
+        laplacian = compute_matting_laplacian(image_np)
+        laplacian = laplacian.to(device=pred.device, dtype=pred.dtype)
+
+        # Compute loss: alpha^T @ L @ alpha
+        # pred is (H, W), flatten to (H*W,) to match Laplacian size (H*W, H*W)
+        alpha_flat = pred.flatten()
+        loss = (
+            alpha_flat @ torch.sparse.mm(laplacian, alpha_flat.unsqueeze(1)).squeeze()
+        ) * self._loss_weight
+        return loss

--- a/sapiens/dense/src/visualizers/__init__.py
+++ b/sapiens/dense/src/visualizers/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .albedo_visualizer import AlbedoVisualizer
+from .matting_visualizer import MattingVisualizer
 from .normal_visualizer import NormalVisualizer
 from .pointmap_visualizer import PointmapVisualizer
 from .seg_visualizer import SegVisualizer
@@ -14,4 +15,5 @@ __all__ = [
     "SegVisualizer",
     "NormalVisualizer",
     "AlbedoVisualizer",
+    "MattingVisualizer",
 ]

--- a/sapiens/dense/src/visualizers/matting_visualizer.py
+++ b/sapiens/dense/src/visualizers/matting_visualizer.py
@@ -1,0 +1,125 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+from sapiens.registry import VISUALIZERS
+from torch import nn
+
+
+@VISUALIZERS.register_module()
+class MattingVisualizer(nn.Module):
+    def __init__(
+        self,
+        output_dir: str,
+        vis_interval: int = 100,
+        vis_max_samples: int = 4,
+        vis_image_width: int = 384,
+        vis_image_height: int = 512,
+    ):
+        super().__init__()
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        self.vis_max_samples = vis_max_samples
+        self.vis_interval = vis_interval
+        self.vis_image_width = vis_image_width
+        self.vis_image_height = vis_image_height
+
+    def add_batch(self, data_batch: dict, logs: dict, step: int):
+        inputs = data_batch["inputs"].detach().cpu()  # B x 3 x H x W
+        pred_alphas = logs["outputs"][:, -1, :, :].detach().cpu()  # B x H x W
+        pred_fgrs = (
+            logs["outputs"][:, 0:3, :, :].detach().cpu()
+            if logs["outputs"].shape[1] == 4
+            else None
+        )  # B x 3 x H x W
+
+        gt_alphas = (data_batch["data_samples"]["gt_alpha"].detach().cpu()).squeeze(
+            dim=1
+        )  # B x H x W
+        if pred_fgrs is not None:
+            gt_fgrs = data_batch["data_samples"]["gt_foreground"].detach().cpu()
+            masks = data_batch["data_samples"]["mask"].detach().cpu().squeeze(dim=1)
+        else:
+            gt_fgrs = None
+            masks = None
+
+        if pred_alphas.dtype == torch.bfloat16:
+            inputs = inputs.float()
+            pred_alphas = pred_alphas.float()
+            pred_fgrs = pred_fgrs.float() if pred_fgrs is not None else None
+
+        batch_size = min(len(inputs), self.vis_max_samples)
+
+        inputs = inputs[:batch_size]
+        gt_alphas = gt_alphas[:batch_size].numpy()  # B x H x W
+        pred_alphas = pred_alphas[:batch_size].numpy()  # B x H x W
+        if pred_fgrs is not None:
+            gt_fgrs = gt_fgrs[:batch_size].numpy()  # B x 3 x H x W
+            pred_fgrs = pred_fgrs[:batch_size].numpy()  # B x 3 x H x W
+            masks = masks[:batch_size].numpy()  # B x H x W
+
+        prefix = os.path.join(self.output_dir, "train")
+        suffix = str(step).zfill(6)
+        vis_images = []
+
+        for i, (input, gt_alpha, pred_alpha) in enumerate(
+            zip(inputs, gt_alphas, pred_alphas)
+        ):
+            image = input.permute(1, 2, 0).cpu().numpy()  # BGR image
+            image = np.ascontiguousarray(image.copy()).astype(np.uint8)
+
+            gt_alpha_vis = (gt_alpha * 255).astype(np.uint8)
+            pred_alpha_vis = (pred_alpha * 255).astype(np.uint8)
+            pred_alpha_vis = np.stack([pred_alpha_vis] * 3, axis=-1)
+            gt_alpha_vis = np.stack([gt_alpha_vis] * 3, axis=-1)
+
+            error_alpha = np.abs(pred_alpha - gt_alpha)  # L1 error
+            error_alpha_vis = (error_alpha * 255).astype(np.uint8)  # Scale to [0, 255]
+            error_alpha_vis = cv2.applyColorMap(
+                error_alpha_vis, cv2.COLORMAP_JET
+            )  # Apply colormap for better visualization
+
+            vis_list = [image, gt_alpha_vis, pred_alpha_vis, error_alpha_vis]
+
+            if pred_fgrs is not None:
+                gt_fgr_vis = (
+                    (gt_fgrs[i] * 255).transpose((1, 2, 0))[:, :, ::-1].astype(np.uint8)
+                )  # RGB to BGR
+                pred_fgr_vis = (
+                    (pred_fgrs[i] * 255)
+                    .transpose((1, 2, 0))[:, :, ::-1]
+                    .astype(np.uint8)
+                )  # RGB to BGR
+
+                error_fgr = np.abs(pred_alpha - gt_alpha) * masks[i]  # L1 error
+                error_fgr_vis = (error_fgr * 255).astype(np.uint8)  # Scale to [0, 255]
+                error_fgr_vis = cv2.applyColorMap(
+                    error_fgr_vis, cv2.COLORMAP_JET
+                )  # Apply colormap for better visualization
+                vis_list += [gt_fgr_vis, pred_fgr_vis, error_fgr_vis]
+
+            vis_image = np.concatenate(
+                vis_list,
+                axis=1,
+            )
+            vis_image = cv2.resize(
+                vis_image,
+                (len(vis_list) * self.vis_image_width, self.vis_image_height),
+                interpolation=cv2.INTER_AREA,
+            )
+            vis_images.append(vis_image)
+
+        grid_image = np.concatenate(vis_images, axis=0)
+        grid_out_file = "{}_{}.jpg".format(prefix, suffix)
+        cv2.imwrite(grid_out_file, grid_image)
+
+        return

--- a/sapiens/dense/tools/vis/vis_matting.py
+++ b/sapiens/dense/tools/vis/vis_matting.py
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from argparse import ArgumentParser
+
+import cv2
+import numpy as np
+import torch
+import torch.nn.functional as F
+from sapiens.dense.models import init_model
+from tqdm import tqdm
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("config", help="Config file")
+    parser.add_argument("checkpoint", help="Checkpoint file")
+    parser.add_argument("--input", help="Input image dir or path list file")
+    parser.add_argument("--output", default=None, help="Path to output dir")
+    parser.add_argument(
+        "--save_pred", action="store_true", help="Save alpha matte as .npy"
+    )
+    parser.add_argument("--device", default="cuda:0", help="Device used for inference")
+    args = parser.parse_args()
+
+    model = init_model(args.config, args.checkpoint, device=args.device)
+    os.makedirs(args.output, exist_ok=True)
+
+    # Get image list
+    if os.path.isdir(args.input):
+        input_dir = args.input
+        image_names = [
+            name
+            for name in sorted(os.listdir(input_dir))
+            if name.endswith((".jpg", ".png", ".jpeg"))
+        ]
+    else:
+        with open(args.input, "r") as f:
+            image_paths = [line.strip() for line in f if line.strip()]
+        image_names = [os.path.basename(path) for path in image_paths]
+        input_dir = os.path.dirname(image_paths[0])
+
+    for image_name in tqdm(image_names, total=len(image_names)):
+        image_path = os.path.join(input_dir, image_name)
+        image = cv2.imread(image_path)  ## BGR
+
+        ##------------------------------------------
+        data = model.pipeline(dict(img=image))  ## resize
+        data = model.data_preprocessor(data)  ## normalize, add batch dim and cast
+        inputs = data["inputs"]
+
+        with torch.no_grad():
+            outputs = model(inputs)  ## 1 x 4 x H x W: [fgr_rgb, alpha]
+
+        outputs = F.interpolate(
+            outputs,
+            size=(image.shape[0], image.shape[1]),
+            mode="bilinear",
+            align_corners=False,
+        )
+
+        outputs = outputs.squeeze(0).float().cpu().numpy()  ## 4 x H x W
+        fgr_rgb = outputs[0:3].clip(0, 1).transpose(1, 2, 0)  ## H x W x 3, RGB premult
+        alpha = outputs[3].clip(0, 1)  ## H x W
+
+        # ------------------------------------------
+        alpha_vis = (alpha * 255).astype(np.uint8)
+        alpha_vis_3ch = np.stack([alpha_vis] * 3, axis=-1)
+
+        # Composite the predicted (pre-multiplied) foreground over a chroma-green
+        # background.
+        fgr_bgr = fgr_rgb[:, :, ::-1]  ## RGB -> BGR
+        bg_bgr = np.array([64, 177, 0], dtype=np.float32) / 255.0  ## chroma green
+        composite = fgr_bgr + (1 - alpha[..., None]) * bg_bgr
+        composite = (composite.clip(0, 1) * 255).astype(np.uint8)
+
+        vis_image = np.concatenate([image, alpha_vis_3ch, composite], axis=1)
+        save_path = os.path.join(args.output, image_name)
+        cv2.imwrite(save_path, vis_image)
+
+        if args.save_pred:
+            base = os.path.splitext(image_name)[0]
+            np.save(os.path.join(args.output, f"{base}_alpha.npy"), alpha)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
  Adds matting as a new dense prediction task, alongside the existing
  albedo / normal / pointmap / seg tasks.

  - Per-pixel alpha matting for human subjects (4-channel output: pre-multiplied
    foreground RGB + alpha)
  - 1B-sized config and training script (`scripts/matting/train/sapiens2_1b/node.sh`)
  - `MattingBaseDataset` (JSON manifest) and `MattingGSSDataset` (RGBA manifest)
  - Training transforms including in-the-wild background augmentation
  - Inference tool (`tools/vis/vis_matting.py`) and demo wrapper
    (`scripts/demo/matting.sh`)
  - `docs/MATTING.md`

  Trained checkpoint will be released separately on HuggingFace.

  ## Test plan
  - [ ] Verified all `__init__.py` registrations import cleanly
  - [ ] Config parses (AST + sapiens registry resolution)
  - [ ] Training script runs in `debug` mode on a single GPU
  - [ ] Demo script runs against a checkpoint